### PR TITLE
fix: 修复byte[]类型的乐观锁初始化问题

### DIFF
--- a/FreeSql/Internal/CommonProvider/InsertProvider.cs
+++ b/FreeSql/Internal/CommonProvider/InsertProvider.cs
@@ -179,7 +179,7 @@ namespace FreeSql.Internal.CommonProvider
                 }
                 if (val == null && col.Attribute.MapType == typeof(string) && col.Attribute.IsNullable == false)
                     col.SetValue(data, val = "");
-                if (val == null && col.Attribute.MapType == typeof(byte[]) && col.Attribute.IsVersion)
+                if (col.Attribute.MapType == typeof(byte[]) && (val == null || (val is byte[] bytes && bytes.Length == 0)) && col.Attribute.IsVersion)
                     col.SetValue(data, val = Utils.GuidToBytes(Guid.NewGuid()));
             }
         }


### PR DESCRIPTION
通过判断`byte[]`的长度，解决`byte[]`默认初始化为`new byte[]`的问题