### PR TITLE
修复数据库默认值为'\'等转义字符导致生成的实体无法通过编译bug

### DIFF
--- a/Extensions/FreeSql.Generator/RazorModel.cs
+++ b/Extensions/FreeSql.Generator/RazorModel.cs
@@ -253,7 +253,7 @@ public class RazorModel
 		if (cstype == typeof(Guid) && Guid.TryParse(defval, out var tryguid)) return isInsertValueSql ? (fsql.Select<TestTb>() as Select0Provider)._commonUtils.FormatSql("{0}", defval) : $"Guid.Parse(\"{defval.Replace("\r\n", "\\r\\n").Replace("\"", "\\\"")}\")";
 		if (cstype == typeof(DateTime) && DateTime.TryParse(defval, out var trydt)) return isInsertValueSql ? (fsql.Select<TestTb>() as Select0Provider)._commonUtils.FormatSql("{0}", defval) : $"DateTime.Parse(\"{defval.Replace("\r\n", "\\r\\n").Replace("\"", "\\\"")}\")";
 		if (cstype == typeof(TimeSpan) && TimeSpan.TryParse(defval, out var tryts)) return isInsertValueSql ? (fsql.Select<TestTb>() as Select0Provider)._commonUtils.FormatSql("{0}", defval) : $"TimeSpan.Parse(\"{defval.Replace("\r\n", "\\r\\n").Replace("\"", "\\\"")}\")";
-		if (cstype == typeof(string)) return isInsertValueSql ? (fsql.Select<TestTb>() as Select0Provider)._commonUtils.FormatSql("{0}", defval) : $"\"{defval.Replace("\r\n", "\\r\\n").Replace("\"", "\\\"")}\"";
+		if (cstype == typeof(string)) return isInsertValueSql ? (fsql.Select<TestTb>() as Select0Provider)._commonUtils.FormatSql("{0}", defval) : $"@\"{defval.Replace("\r\n", "\\r\\n").Replace("\"", "\\\"")}\"";
 		if (cstype == typeof(bool)) return isInsertValueSql ? defval : (defval == "1" || defval == "t" ? "true" : "false");
 		if (fsql.Ado.DataType == DataType.MySql || fsql.Ado.DataType == DataType.OdbcMySql)
 			if (col.DbType == (int)MySqlDbType.Enum || col.DbType == (int)MySqlDbType.Set)


### PR DESCRIPTION
生成的字符串格式多一个@符，在模板文件中无法判定当前生成的字段为string类型，因此修改代码实现修复转义字符bug
[JsonProperty, Column(DbType = "NVARCHAR", IsPrimary = true, IsNullable = false)]
public string syscfg_ID { get; set; } = @"";