### PR TITLE
修复: sqlserver row_number排序不一致

### DIFF
--- a/Providers/FreeSql.Provider.Odbc/SqlServer/Curd/OdbcSqlServerSelect.cs
+++ b/Providers/FreeSql.Provider.Odbc/SqlServer/Curd/OdbcSqlServerSelect.cs
@@ -41,14 +41,15 @@ namespace FreeSql.Odbc.SqlServer
                 //if (_limit > 0) sb.Append("TOP ").Append(_skip + _limit).Append(" "); //TOP 会引发 __rownum__ 无序的问题
                 if (_skip <= 0 && _limit > 0) sb.Append("TOP ").Append(_limit).Append(" ");
                 sb.Append(field);
+
+                if (string.IsNullOrEmpty(_orderby))
+                {
+                    var pktb = _tables.Where(a => a.Table.Primarys.Any()).FirstOrDefault();
+                    if (pktb != null) _orderby = string.Concat(" \r\nORDER BY ", pktb.Alias, ".", _commonUtils.QuoteSqlName(pktb?.Table.Primarys.First().Attribute.Name));
+                    else _orderby = string.Concat(" \r\nORDER BY ", _tables.First().Alias, ".", _commonUtils.QuoteSqlName(_tables.First().Table.Columns.First().Value.Attribute.Name));
+                }
                 if (_skip > 0)
                 {
-                    if (string.IsNullOrEmpty(_orderby))
-                    {
-                        var pktb = _tables.Where(a => a.Table.Primarys.Any()).FirstOrDefault();
-                        if (pktb != null) _orderby = string.Concat(" \r\nORDER BY ", pktb.Alias, ".", _commonUtils.QuoteSqlName(pktb?.Table.Primarys.First().Attribute.Name));
-                        else _orderby = string.Concat(" \r\nORDER BY ", _tables.First().Alias, ".", _commonUtils.QuoteSqlName(_tables.First().Table.Columns.First().Value.Attribute.Name));
-                    }
                     sb.Append(", ROW_NUMBER() OVER(").Append(_orderby).Append(") AS __rownum__");
                 }
                 sb.Append(" \r\nFROM ");

--- a/Providers/FreeSql.Provider.Odbc/SqlServer/Curd/OdbcSqlServerSelect.cs
+++ b/Providers/FreeSql.Provider.Odbc/SqlServer/Curd/OdbcSqlServerSelect.cs
@@ -42,15 +42,16 @@ namespace FreeSql.Odbc.SqlServer
                 if (_skip <= 0 && _limit > 0) sb.Append("TOP ").Append(_limit).Append(" ");
                 sb.Append(field);
 
-                if (string.IsNullOrEmpty(_orderby))
+                if (_limit > 0)
                 {
-                    var pktb = _tables.Where(a => a.Table.Primarys.Any()).FirstOrDefault();
-                    if (pktb != null) _orderby = string.Concat(" \r\nORDER BY ", pktb.Alias, ".", _commonUtils.QuoteSqlName(pktb?.Table.Primarys.First().Attribute.Name));
-                    else _orderby = string.Concat(" \r\nORDER BY ", _tables.First().Alias, ".", _commonUtils.QuoteSqlName(_tables.First().Table.Columns.First().Value.Attribute.Name));
-                }
-                if (_skip > 0)
-                {
-                    sb.Append(", ROW_NUMBER() OVER(").Append(_orderby).Append(") AS __rownum__");
+                    if (string.IsNullOrEmpty(_orderby))
+                    {
+                        var pktb = _tables.Where(a => a.Table.Primarys.Any()).FirstOrDefault();
+                        if (pktb != null) _orderby = string.Concat(" \r\nORDER BY ", pktb.Alias, ".", _commonUtils.QuoteSqlName(pktb?.Table.Primarys.First().Attribute.Name));
+                        else _orderby = string.Concat(" \r\nORDER BY ", _tables.First().Alias, ".", _commonUtils.QuoteSqlName(_tables.First().Table.Columns.First().Value.Attribute.Name));
+                    }
+                    if (_skip > 0) // 注意这个判断，大于 0 才使用 ROW_NUMBER ，否则属于第一页直接使用 TOP
+                        sb.Append(", ROW_NUMBER() OVER(").Append(_orderby).Append(") AS __rownum__");
                 }
                 sb.Append(" \r\nFROM ");
                 var tbsjoin = _tables.Where(a => a.Type != SelectTableInfoType.From).ToArray();

--- a/Providers/FreeSql.Provider.SqlServer/Curd/SqlServerSelect.cs
+++ b/Providers/FreeSql.Provider.SqlServer/Curd/SqlServerSelect.cs
@@ -41,7 +41,8 @@ namespace FreeSql.SqlServer.Curd
                 //if (_limit > 0) sb.Append("TOP ").Append(_skip + _limit).Append(" "); //TOP 会引发 __rownum__ 无序的问题
                 if (_skip <= 0 && _limit > 0) sb.Append("TOP ").Append(_limit).Append(" ");
                 sb.Append(field);
-                if (_skip > 0)
+
+                if (_limit > 0)
                 {
                     if (string.IsNullOrEmpty(_orderby))
                     {
@@ -49,7 +50,8 @@ namespace FreeSql.SqlServer.Curd
                         if (pktb != null) _orderby = string.Concat(" \r\nORDER BY ", pktb.Alias, ".", _commonUtils.QuoteSqlName(pktb?.Table.Primarys.First().Attribute.Name));
                         else _orderby = string.Concat(" \r\nORDER BY ", _tables.First().Alias, ".", _commonUtils.QuoteSqlName(_tables.First().Table.Columns.First().Value.Attribute.Name));
                     }
-                    sb.Append(", ROW_NUMBER() OVER(").Append(_orderby).Append(") AS __rownum__");
+                    if (_skip > 0) // 注意这个判断，大于 0 才使用 ROW_NUMBER ，否则属于第一页直接使用 TOP
+                        sb.Append(", ROW_NUMBER() OVER(").Append(_orderby).Append(") AS __rownum__");
                 }
                 sb.Append(" \r\nFROM ");
                 var tbsjoin = _tables.Where(a => a.Type != SelectTableInfoType.From).ToArray();


### PR DESCRIPTION
在不存在任何OrderBy的情况下.   
 ```skip != 0```时会生成一个默认排序给```ROW_NUMBER```   
```skip == 0```时会按照原先sql的默认排序导致的排序不一致的问题


修改:
当```skip == 0```并且不存在OrderBy的情况下生成和```skip != 0```同样的默认排序
