### PR TITLE
对 AdoNetExtensions 新增和修复功能

### DIFF
--- a/FreeSql.Tests/FreeSql.Tests/AdoNetExtensions/NpgsqlConnectionExtensionsTest.cs
+++ b/FreeSql.Tests/FreeSql.Tests/AdoNetExtensions/NpgsqlConnectionExtensionsTest.cs
@@ -1,16 +1,36 @@
-using Npgsql;
+﻿using Npgsql;
 using System;
 using System.Collections.Generic;
 using Xunit;
 
 namespace FreeSql.Tests.AdoNetExtensions.NpgsqlConnectionExtensions {
-	public class Methods {
+
+    [Collection("AdoNetExtensions")]
+	public class Methods : IDisposable {
 
 		string _connectString = "Host=192.168.164.10;Port=5432;Username=postgres;Password=123456;Database=tedb;Pooling=true;Maximum Pool Size=5";
 
 		public Methods() {
 			g.pgsql.CodeFirst.SyncStructure<TestConnectionExt>();
+            FreeSql.AdoNetExtensions.AdoNetFreeSqlCreated += AdoNetExtensions_AdoNetFreeSqlCreated;
 		}
+        
+        public void Dispose()
+        {
+            FreeSql.AdoNetExtensions.AdoNetFreeSqlCreated -= AdoNetExtensions_AdoNetFreeSqlCreated;
+        }
+
+        private static int _adoNetFreeSqlCreatedCount;
+
+        private static void AdoNetExtensions_AdoNetFreeSqlCreated(object sender, AdoNetFreeSqlCreatedEventArgs e)
+        {
+            Assert.True(sender is NpgsqlConnection, sender.GetType().FullName);
+            Assert.Contains("PostgreSQLProvider", e.FreeSql.GetType().FullName);
+
+            _adoNetFreeSqlCreatedCount++;
+
+            Assert.Equal(1, _adoNetFreeSqlCreatedCount);
+        }
 
 		[Fact]
 		public void Insert() {

--- a/FreeSql.Tests/FreeSql.Tests/AdoNetExtensions/OracleConnectionExtensionsTest.cs
+++ b/FreeSql.Tests/FreeSql.Tests/AdoNetExtensions/OracleConnectionExtensionsTest.cs
@@ -1,16 +1,37 @@
-using Oracle.ManagedDataAccess.Client;
+﻿using Oracle.ManagedDataAccess.Client;
 using System;
 using System.Collections.Generic;
 using Xunit;
 
 namespace FreeSql.Tests.AdoNetExtensions.OracleConnectionExtensions {
-	public class Methods {
+
+    [Collection("AdoNetExtensions")]
+	public class Methods : IDisposable {
 
 		string _connectString = "user id=1user;password=123456;data source=//127.0.0.1:1521/XE;Pooling=true;Max Pool Size=5";
 
 		public Methods() {
 			g.oracle.CodeFirst.SyncStructure<TestConnectionExt>();
+            FreeSql.AdoNetExtensions.AdoNetFreeSqlCreated += AdoNetExtensions_AdoNetFreeSqlCreated;
 		}
+
+
+        public void Dispose()
+        {
+            FreeSql.AdoNetExtensions.AdoNetFreeSqlCreated -= AdoNetExtensions_AdoNetFreeSqlCreated;
+		}
+
+        private static int _adoNetFreeSqlCreatedCount;        
+
+		private static void AdoNetExtensions_AdoNetFreeSqlCreated(object sender, AdoNetFreeSqlCreatedEventArgs e)
+        {
+            Assert.True(sender is OracleConnection, sender.GetType().FullName);
+            Assert.Contains("OracleProvider", e.FreeSql.GetType().FullName);
+			
+            _adoNetFreeSqlCreatedCount++;
+
+            Assert.Equal(1, _adoNetFreeSqlCreatedCount);
+        }
 
 		[Fact]
 		public void Insert() {

--- a/FreeSql.Tests/FreeSql.Tests/AdoNetExtensions/SQLiteConnectionExtensionsTest.cs
+++ b/FreeSql.Tests/FreeSql.Tests/AdoNetExtensions/SQLiteConnectionExtensionsTest.cs
@@ -1,17 +1,39 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Data.SQLite;
+using Microsoft.Data.SqlClient;
 using Xunit;
 
 namespace FreeSql.Tests.AdoNetExtensions.SQLiteConnectionExtensions {
-	public class Methods {
+	
+    [Collection("AdoNetExtensions")]
+    public class Methods : IDisposable {
 
 		string _connectString = "Data Source=|DataDirectory|/document.db;Attachs=xxxtb.db;Pooling=true;Max Pool Size=5";
 
 		public Methods() {
 			g.sqlite.CodeFirst.SyncStructure<TestConnectionExt>();
+            
+            FreeSql.AdoNetExtensions.AdoNetFreeSqlCreated += AdoNetExtensions_AdoNetFreeSqlCreated;
+		}
+        
+        public void Dispose()
+        {
+            FreeSql.AdoNetExtensions.AdoNetFreeSqlCreated -= AdoNetExtensions_AdoNetFreeSqlCreated;
+        }
+        
+		private static int _adoNetFreeSqlCreatedCount;
+
+		private static void AdoNetExtensions_AdoNetFreeSqlCreated(object sender, AdoNetFreeSqlCreatedEventArgs e)
+        {
+            Assert.True(sender is SQLiteConnection, sender.GetType().FullName);
+            Assert.Contains("SqliteProvider", e.FreeSql.GetType().FullName);
+            
+            _adoNetFreeSqlCreatedCount++;
+
+            Assert.Equal(1, _adoNetFreeSqlCreatedCount);
 		}
 
 		[Fact]

--- a/FreeSql/FreeSql.xml
+++ b/FreeSql/FreeSql.xml
@@ -1040,6 +1040,11 @@
             </summary>
             <returns></returns>
         </member>
+        <member name="P:FreeSql.AdoNetFreeSqlCreatedEventArgs.FreeSql">
+            <summary>
+            创建的 IFreeSql 实例
+            </summary>
+        </member>
         <member name="M:FreeSql.Extensions.EntityUtil.EntityUtilExtensions.GetEntityKeyString(IFreeSql,System.Type,System.Object,System.Boolean,System.String)">
             <summary>
             获取实体的主键值，以 "*|_,[,_|*" 分割，当任意一个主键属性无值时，返回 null


### PR DESCRIPTION
手头没有那么多测试环境，已经测试 SqlServer, Sqlite.

- 修复 DbConnection ConnectionString 在 Open 后会移除密码字段, 导致多次创建 IFreeSql 对象;
- 新增 使用 ConcurrentDictionary 管理 AdoNet to IFreeSql 对象;
- 新增 在 AdoNetExtensions 增加事件获取 FreeSql 内部创建的 IFreeSql 对象;