### PR TITLE
fix: 无构造函数的对象不跟踪（基本上都是dto对象）

### DIFF
--- a/FreeSql.DbContext/DbSet/DbSet.cs
+++ b/FreeSql.DbContext/DbSet/DbSet.cs
@@ -100,6 +100,7 @@ namespace FreeSql
                     if (itemType == typeof(object)) return;
                     if (itemType.FullName.Contains("FreeSqlLazyEntity__")) itemType = itemType.BaseType;
                     if (_db.OrmOriginal.CodeFirst.GetTableByEntity(itemType)?.Primarys.Any() != true) return;
+                    if (itemType.GetConstructor(System.Type.EmptyTypes) == null) return;
                     var dbset = _db.Set(itemType);
                     dbset?.GetType().GetMethod("TrackToList", BindingFlags.Instance | BindingFlags.NonPublic).Invoke(dbset, new object[] { list });
                     return;


### PR DESCRIPTION
ISelect的ToList和First对象如果没有空的构造函数，则会在CreateEntityState的时候引发异常

以下为示例代码：


    using FreeSql;
    using FreeSql.DataAnnotations;
  
    var fsql = new FreeSql.FreeSqlBuilder()
        .UseConnectionString(DataType.Sqlite, "Data Source=mydata.db")
        .UseAutoSyncStructure(true)
        .Build();
    
    fsql.CodeFirst.SyncStructure<MyDataEntity>();
    fsql.GetRepository<MyDataEntity>().Insert(new MyDataEntity { Name = "my name" + DateTime.Now.ToString("yyyyMMddTHHmmss") });
    
    var uowm = new UnitOfWorkManager(fsql);
    
    using var uow = uowm.Begin();
    
    var repository = uow.Orm.GetRepository<MyDataEntity, int>();
    
    var firstData = await repository.Select.FirstAsync((o) => new MyDataDto(o.Id) { Name = o.Name }, default);
    Console.WriteLine("Success firstData");
    try
    {
        // MyDataDtoError因为没有MyDataDtoError()的构造函数，则会在Orm跟踪的时候引发异常。
        var errorData = await repository.Select.FirstAsync((o) => new MyDataDtoError(o.Id, o.Name) { Name = o.Name }, default);
        Console.WriteLine("Success errorData");
    }
    catch (Exception ex)
    {
        Console.WriteLine("Error errorData:{0}", ex.Message);
    }
    Console.WriteLine("End");
    
    [Table(Name = "MyData")]
    public class MyDataEntity
    {
        [Column(IsPrimary = true, IsIdentity = true)]
        public int Id { get; set; }
        public string? Name { get; set; }
    }
    
    public class MyDataDto : MyDataDtoError
    {
        public MyDataDto() : base(0) { }
        public MyDataDto(int id) : base(id) { }
    }

    public class MyDataDtoError
    {
        public MyDataDtoError(int id)
        {
            Id = id;
        }
    
        public MyDataDtoError(int id, string title)
        {
            Id = id;
            Title = title;
        }
        public int Id { get; set; }
        public string? Name { get; set; }
        public string? Title { get; }
    }
