### PR TITLE
fix: 修复实体对象无空构造函数时通过Repository操作引发异常的问题,增加Lazy改进并发

### DIFF
--- a/FreeSql.DbContext/DbSet/DbSet.cs
+++ b/FreeSql.DbContext/DbSet/DbSet.cs
@@ -219,7 +219,7 @@ namespace FreeSql
         public DbSet<TEntity> AttachOnlyPrimary(TEntity data)
         {
             if (data == null) return this;
-            var pkitem = (TEntity)Activator.CreateInstance(_entityType);
+            var pkitem = (TEntity)_entityType.CreateInstanceGetDefaultValue();
             foreach (var pk in _db.OrmOriginal.CodeFirst.GetTableByEntity(_entityType).Primarys)
             {
                 var colVal = _db.OrmOriginal.GetEntityValueWithPropertyName(_entityType, data, pk.CsName);
@@ -267,8 +267,8 @@ namespace FreeSql
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
             var key = _db.OrmOriginal.GetEntityKeyString(_entityType, data, false);
-            var state = new EntityState((TEntity)Activator.CreateInstance(_entityType), key);
-            _db.OrmOriginal.MapEntityValue(_entityType, data, state.Value);
+            var state = new EntityState((TEntity)_entityType.CreateInstanceGetDefaultValue(), key);
+           _db.OrmOriginal.MapEntityValue(_entityType, data, state.Value);
             return state;
         }
         bool? ExistsInStates(TEntity data)

--- a/FreeSql.DbContext/DbSet/DbSetAsync.cs
+++ b/FreeSql.DbContext/DbSet/DbSetAsync.cs
@@ -312,7 +312,7 @@ namespace FreeSql
                             midSet.RemoveRange(midListDel); //删除未保存的项
                             foreach (var curItem in curList)
                             {
-                                var newItem = Activator.CreateInstance(tref.RefMiddleEntityType);
+                                var newItem = tref.RefMiddleEntityType.CreateInstanceGetDefaultValue();
                                 for (var colidx = 0; colidx < tref.Columns.Count; colidx++)
                                 {
                                     var val = FreeSql.Internal.Utils.GetDataReaderValue(tref.MiddleColumns[colidx].CsType, _db.OrmOriginal.GetEntityValueWithPropertyName(_table.Type, item, tref.Columns[colidx].CsName));

--- a/FreeSql.DbContext/DbSet/DbSetSync.cs
+++ b/FreeSql.DbContext/DbSet/DbSetSync.cs
@@ -323,7 +323,7 @@ namespace FreeSql
                             midSet.RemoveRange(midListDel); //删除未保存的项
                             foreach (var curItem in curList)
                             {
-                                var newItem = Activator.CreateInstance(tref.RefMiddleEntityType);
+                                var newItem = tref.RefMiddleEntityType.CreateInstanceGetDefaultValue();
                                 for (var colidx = 0; colidx < tref.Columns.Count; colidx++)
                                 {
                                     var val = FreeSql.Internal.Utils.GetDataReaderValue(tref.MiddleColumns[colidx].CsType, _db.OrmOriginal.GetEntityValueWithPropertyName(_table.Type, item, tref.Columns[colidx].CsName));

--- a/FreeSql.DbContext/Repository/Repository/BaseRepository.cs
+++ b/FreeSql.DbContext/Repository/Repository/BaseRepository.cs
@@ -197,7 +197,7 @@ namespace FreeSql
             var tb = _db.OrmOriginal.CodeFirst.GetTableByEntity(EntityType);
             if (tb.Primarys.Length != 1) throw new Exception(DbContextStrings.EntityType_PrimaryKeyIsNotOne(EntityType.Name));
             if (tb.Primarys[0].CsType.NullableTypeOrThis() != typeof(TKey).NullableTypeOrThis()) throw new Exception(DbContextStrings.EntityType_PrimaryKeyError(EntityType.Name, typeof(TKey).FullName));
-            var obj = Activator.CreateInstance(tb.Type);
+            var obj = tb.Type.CreateInstanceGetDefaultValue();
             _db.OrmOriginal.SetEntityValueWithPropertyName(tb.Type, obj, tb.Primarys[0].CsName, id);
             var ret = obj as TEntity;
             if (ret == null) throw new Exception(DbContextStrings.EntityType_CannotConvert(EntityType.Name, typeof(TEntity).Name));


### PR DESCRIPTION
当实体对象无空构造函数时:
直接使用fsql操作是正常的。
使用DbContent/Repository进行操作会引发异常。但是数据又会成功插入数据库中
<img width="942" alt="image" src="https://user-images.githubusercontent.com/5291698/181006313-786c3a20-1a8d-4688-a38c-dfade3408dd2.png">
![image](https://user-images.githubusercontent.com/5291698/181006365-810ff38a-fcc8-4843-b666-357e0ad84a40.png)

以下为示例代码

    using FreeSql;
    using FreeSql.DataAnnotations;
    
    var fsql = new FreeSql.FreeSqlBuilder()
        .UseConnectionString(DataType.Sqlite, "Data Source=mydata.db")
        .UseAutoSyncStructure(true)
        .Build();
    
    fsql.CodeFirst.SyncStructure<MyDataEntity>();
    // ok
    fsql.Insert(new MyDataEntity("desc") { Name = "my name fsql " + DateTime.Now.ToString("yyyyMMddTHHmmss") }).ExecuteIdentity();
    try
    {
        // error
        fsql.GetRepository<MyDataEntity>().Insert(new MyDataEntity("desc") { Name = "my name repo " + DateTime.Now.ToString("yyyyMMddTHHmmss") });
        Console.WriteLine("Success InsertEntityData");
    }
    catch (Exception ex)
    {
        Console.WriteLine("Error InsertEntityData:{0}", ex.Message);
    }
    
    var uowm = new UnitOfWorkManager(fsql);
    
    using var uow = uowm.Begin();
    
    var repository = uow.Orm.GetRepository<MyDataEntity, int>();
    
    try
    {
        var entityData = await repository.Select.FirstAsync((o) => new MyDataEntity(o.Desc) { Name = o.Name });
        var entityDataLast = await repository.Select.OrderByDescending(o => o.Id).FirstAsync();
        Console.WriteLine("Success EntityData");
    }
    catch (Exception ex)
    {
        Console.WriteLine("Error EntityData:{0}", ex.Message);
    }

    [Table(Name = "MyData")]
    public class MyDataEntity
    {
        public MyDataEntity(string? desc)
        {
            Desc = desc;
        }
        [Column(IsPrimary = true, IsIdentity = true)]
        public int Id { get; set; }
        public string? Name { get; set; }
        public string? Desc { get; private set; }
    }