### PR TITLE
refactor: 优化判断表是否存在的查询语句

### DIFF
--- a/Providers/FreeSql.Provider.MySql/MySqlCodeFirst.cs
+++ b/Providers/FreeSql.Provider.MySql/MySqlCodeFirst.cs
@@ -212,7 +212,7 @@ where a.table_schema in ({0}) and a.table_name in ({1})", tboldname ?? tbname);
 
                     if (istmpatler == false)
                     {
-                        var existsPrimary = LocalExecuteScalar(tbname[0], _commonUtils.FormatSql(" select 1 from information_schema.key_column_usage where table_schema={0} and table_name={1} and constraint_name = 'PRIMARY' limit 1", tbname));
+                        var existsPrimary = LocalExecuteScalar(tbname[0], _commonUtils.FormatSql(" select 1 from information_schema.columns where table_schema={0} and table_name={1} and column_key = 'PRI' limit 1", tbname));
                         foreach (var tbcol in tb.ColumnsByPosition)
                         {
                             if (tbstruct.TryGetValue(tbcol.Attribute.Name, out var tbstructcol) ||

--- a/Providers/FreeSql.Provider.Odbc/MySql/OdbcMySqlCodeFirst.cs
+++ b/Providers/FreeSql.Provider.Odbc/MySql/OdbcMySqlCodeFirst.cs
@@ -201,7 +201,7 @@ where a.table_schema in ({0}) and a.table_name in ({1})", tboldname ?? tbname);
 
                     if (istmpatler == false)
                     {
-                        var existsPrimary = LocalExecuteScalar(tbname[0], _commonUtils.FormatSql(" select 1 from information_schema.key_column_usage where table_schema={0} and table_name={1} and constraint_name = 'PRIMARY' limit 1", tbname));
+                        var existsPrimary = LocalExecuteScalar(tbname[0], _commonUtils.FormatSql(" select 1 from information_schema.columns where table_schema={0} and table_name={1} and column_key = 'PRI' limit 1", tbname));
                         foreach (var tbcol in tb.ColumnsByPosition)
                         {
                             var isIdentityChanged = tbcol.Attribute.IsIdentity == true && tbcol.Attribute.DbType.IndexOf("AUTO_INCREMENT", StringComparison.CurrentCultureIgnoreCase) == -1;


### PR DESCRIPTION
当库的表数量较多的时候，查询是否存在主键存在极大的延迟

<img width="348" alt="企业微信截图_6ebff96b-0c23-444d-8686-1e04a3cea8aa" src="https://user-images.githubusercontent.com/5291698/201937460-a9d96e01-9590-49b8-8480-5d8784967306.png">

key_column_usage：288s

<img width="608" alt="image" src="https://user-images.githubusercontent.com/5291698/201938752-26a1c49d-a74b-48c3-8f7e-940a93d9f472.png">

columns: 0.033s
<img width="592" alt="image" src="https://user-images.githubusercontent.com/5291698/201938992-06475d4b-57fa-48fd-b302-e1f45175c91a.png">


https://dev.mysql.com/doc/refman/5.6/en/information-schema-optimization.html
![image](https://user-images.githubusercontent.com/5291698/201938097-69e988e9-bdc5-4965-bc96-c28030bda2f8.png)
使用key_column_usage进行查询的话必须打开 .frm、.MYD 和 .MYI 文件进行检索性能极低

