### PR TITLE
fix: 修复由于调用顺序不同导致 ExpressionTree conversion error

### DIFF
--- a/Extensions/FreeSql.Extensions.JsonMap/JsonMapCore.cs
+++ b/Extensions/FreeSql.Extensions.JsonMap/JsonMapCore.cs
@@ -53,13 +53,13 @@ public static class FreeSqlJsonMapCoreExtensions
             var isJsonMap = e.Property.GetCustomAttributes(typeof(JsonMapAttribute), false).Any() || _dicJsonMapFluentApi.TryGetValue(e.EntityType, out var tryjmfu) && tryjmfu.ContainsKey(e.Property.Name);
             if (isJsonMap)
             {
+                e.ModifyResult.MapType = typeof(string);
+                e.ModifyResult.StringLength = -2;
                 // 如果将string/string?类型打上JsonMap的标签，会导致其他类型MapType转换为string的时候在一定情况下会引发异常（比如枚举指定MapType=typeof(string)）
                 if (e.Property.PropertyType == typeof(string))
                 {
                     return;
                 }
-                e.ModifyResult.MapType = typeof(string);
-                e.ModifyResult.StringLength = -2;
                 if (_dicTypes.TryAdd(e.Property.PropertyType, true))
                 {
                     lock (_concurrentObj)

--- a/Extensions/FreeSql.Extensions.JsonMap/JsonMapCore.cs
+++ b/Extensions/FreeSql.Extensions.JsonMap/JsonMapCore.cs
@@ -53,6 +53,11 @@ public static class FreeSqlJsonMapCoreExtensions
             var isJsonMap = e.Property.GetCustomAttributes(typeof(JsonMapAttribute), false).Any() || _dicJsonMapFluentApi.TryGetValue(e.EntityType, out var tryjmfu) && tryjmfu.ContainsKey(e.Property.Name);
             if (isJsonMap)
             {
+                // 如果将string/string?类型打上JsonMap的标签，会导致其他类型MapType转换为string的时候在一定情况下会引发异常（比如枚举指定MapType=typeof(string)）
+                if (e.Property.PropertyType == typeof(string))
+                {
+                    return;
+                }
                 e.ModifyResult.MapType = typeof(string);
                 e.ModifyResult.StringLength = -2;
                 if (_dicTypes.TryAdd(e.Property.PropertyType, true))


### PR DESCRIPTION
如果将string/string?类型打上JsonMap的标签，会导致其他类型MapType转换为string的时候在一定情况下会引发异常（比如枚举指定MapType=typeof(string)）

问题产生原因是在调用GetDataReaderValue时会先调用JsonMap的拦截器
GetDataReaderValueBlockExpressionSwitchTypeFullName
当JsonMap中的拦截器_dicTypes字典中含有string类型时，会导致所有类型转换为string的转换函数使用JsonMap的转换函数，从而引发类型转换失败。

``` csharp
public class TransferData1
{
    [Column(IsPrimary = true, IsIdentity = true)]
    public long Id { get; set; }

    public string Name { get; set; } = null!;

    [JsonMap]  // 添加此标签会引发异常
    public string? NameErr { get; set; } = null!;
}

public class TransferData2
{
    [Column(IsPrimary = true, IsIdentity = true)]
    public long Id { get; set; }

    public string Name { get; set; } = null!;

    [Column(MapType = typeof(string))]
    public TEnum MyEnum { get; set; }
}

public enum TEnum
{
    A,
    B,
    C
}

private async Task T1()
{
    var wr = await freeSql.Insert(new TransferData1()).ExecuteAffrowsAsync();
}

private async Task T2()
{
    var count = await freeSql.Select<TransferData2>().Where(o => o.MyEnum == TEnum.C).CountAsync();
}

// 服务启动后 首次先调用T1，再调用T2，将永远引发异常
await T1();
await T2();
// Throw Exception
// ExpressionTree 转换类型错误，值(A)，类型(Test.Controllers.TEnum)，目标类型(System.String)，Unable to cast object of type 'Test.Controllers.TEnum' to type 'System.String'.

// 服务启动后 首次先调用T2，再调用T1，将永远不引发异常
await T2();
await T1();
// Success
```