### PR TITLE
优化当props属性过多时的判断

### DIFF
--- a/FreeSql/Internal/CommonProvider/SelectProvider/Select0ProviderReader.cs
+++ b/FreeSql/Internal/CommonProvider/SelectProvider/Select0ProviderReader.cs
@@ -632,7 +632,7 @@ namespace FreeSql.Internal.CommonProvider
                             a.Alias.StartsWith($"{tb.Alias}__") && //开头结尾完全匹配
                             a.Alias.EndsWith($"__{prop.Name}") //不清楚会不会有其他情况 求大佬优化
                             ).FirstOrDefault(); //判断 b > 0 防止 parent 递归关系
-                        if (tb2 == null && props.Where(pw => pw.Value.PropertyType == prop.PropertyType).Count() == 1)
+                        if (tb2 == null && props.Where(pw => pw.Value.PropertyType == prop.PropertyType).Take(2).Count() == 1)
                             tb2 = _tables.Where((a, b) => b > 0 &&
                                 (a.Type == SelectTableInfoType.InnerJoin || a.Type == SelectTableInfoType.LeftJoin || a.Type == SelectTableInfoType.RightJoin) &&
                                 string.IsNullOrEmpty(a.On) == false &&


### PR DESCRIPTION
优化当props属性过多时且有过多的属性与prop属性类型一样的时候,只需要迭代到第二次即可判断出是否等于1，无需一直迭代到全属性遍历完