### PR TITLE
修复使用SqliteCore包无法使用GetCrud方法问题

### DIFF
--- a/FreeSql/Extensions/AdoNetExtensions.cs
+++ b/FreeSql/Extensions/AdoNetExtensions.cs
@@ -40,8 +40,9 @@ namespace FreeSql
                     if (providerType == null) throw new Exception(CoreStrings.Missing_FreeSqlProvider_Package("Oracle"));
                     break;
                 case "SQLiteConnection":
+                case "SqliteConnection":
                     providerType = Type.GetType("FreeSql.Sqlite.SqliteProvider`1,FreeSql.Provider.Sqlite")?.MakeGenericType(connType);
-                    if (providerType == null) throw new Exception(CoreStrings.Missing_FreeSqlProvider_Package("Sqlite"));
+                    if (providerType == null) throw new Exception(CoreStrings.Missing_FreeSqlProvider_Package("Sqlite/SqliteCore"));
                     break;
                 case "DmConnection":
                     providerType = Type.GetType("FreeSql.Dameng.DamengProvider`1,FreeSql.Provider.Dameng")?.MakeGenericType(connType);


### PR DESCRIPTION
FreeSql.Provider.SqliteCore 所使用包的ado连接类名为SqliteConnection ， 与现有判断的类名大小写不一致，添加以进行兼容