### PR TITLE
添加 通过DTO 进行update的方法, 特点是,忽略值为null的属性.

### DIFF
--- a/FreeSql/Internal/CommonProvider/UpdateProvider.cs
+++ b/FreeSql/Internal/CommonProvider/UpdateProvider.cs
@@ -777,6 +777,38 @@ namespace FreeSql.Internal.CommonProvider
             }
             return this;
         }
+        public IUpdate<T1> SetDtoIgnoreNull(object dto)
+        {
+            if (dto == null) return this;
+            if (dto is Dictionary<string, object>)
+            {
+                var dic = dto as Dictionary<string, object>;
+                foreach (var kv in dic)
+                {
+                    if (kv.Value == null)
+                    {
+                        continue;
+                    }
+                    if (_table.ColumnsByCs.TryGetValue(kv.Key, out var trycol) == false) continue;
+                    if (_ignore.ContainsKey(trycol.Attribute.Name)) continue;
+                    SetPriv(trycol, kv.Value);
+                }
+                return this;
+            }
+            var dtoProps = dto.GetType().GetProperties();
+            foreach (var dtoProp in dtoProps)
+            {
+                var v3 = dtoProp.GetValue(dto, null);
+                if (v3 == null)
+                {
+                    continue;
+                }
+                if (_table.ColumnsByCs.TryGetValue(dtoProp.Name, out var trycol) == false) continue;
+                if (_ignore.ContainsKey(trycol.Attribute.Name)) continue;
+                SetPriv(trycol, v3);
+            }
+            return this;
+        }
 
         public IUpdate<T1> Where(Expression<Func<T1, bool>> exp) => WhereIf(true, exp);
         public IUpdate<T1> WhereIf(bool condition, Expression<Func<T1, bool>> exp)


### PR DESCRIPTION
说明:在开发的时候,希望代码能实现更高的复用,那么一个编辑方法,我希望在多个不同的场景都可以使用. 但是不同场景涉及的字段有时不一样的,每次都把完整的DTO实体生成出来,既繁琐,又容易出错, 于是想升级这个方法, 不想update的字段,为null就好了,这样不会影响数据库中的原有值. 只更新有实际意义的字段.