### PR TITLE
DynamicEntity.DynamicCompileBuilder增加TypeBuilder只读属性和仅构建类型的方法

### DIFF
--- a/FreeSql/Extensions/DynamicEntityExtensions.cs
+++ b/FreeSql/Extensions/DynamicEntityExtensions.cs
@@ -406,6 +406,15 @@ namespace FreeSql.Extensions.DynamicEntity
         /// <returns></returns>
         public TableInfo Build()
         {
+            return _fsql.CodeFirst.GetTableByEntity(BuildJustType());
+        }
+
+        /// <summary>
+        /// Emit动态创建出Class - Type，不附带获取TableInfo
+        /// </summary>
+        /// <returns></returns>
+        public Type BuildJustType()
+        {
             //设置TableAttribute
             SetTableAttribute(ref _typeBuilder);
 
@@ -413,9 +422,7 @@ namespace FreeSql.Extensions.DynamicEntity
             SetPropertys(ref _typeBuilder);
 
             //创建类的Type对象
-            var type = _typeBuilder.CreateTypeInfo().AsType();
-
-            return _fsql.CodeFirst.GetTableByEntity(type);
+            return _typeBuilder.CreateTypeInfo().AsType();
         }
 
         /// <summary>


### PR DESCRIPTION
解决动态实体创建时需要引用自身类型或存在交叉引用时无法使用正在创建的实体类问题。

测试创建一个多级区域的Area实体：
```C#
var fsql = new FreeSqlBuilder()
    .UseConnectionString(DataType.Sqlite, "Data Source=|DataDirectory|\\test.db; Pooling=true;Min Pool Size=1")
    .Build();

// 动态构建实体类型，树形结构，引用自身类型
var areaBuilder = fsql.CodeFirst.DynamicEntity("Area", new TableAttribute { Name = "dy_area" });

areaBuilder.Property("id", typeof(int), new ColumnAttribute { IsPrimary = true })
    .Property("parentId", typeof(int?))
    .Property("name", typeof(string), new ColumnAttribute { StringLength = 30 });

// builder.TypeBuilder可作为类型被引用
areaBuilder.Property("parent", areaBuilder.TypeBuilder, new NavigateAttribute { Bind = "parentId" })
    .Property("children", typeof(List<>).MakeGenericType(areaBuilder.TypeBuilder), new NavigateAttribute { Bind = "parentId" });

var table = areaBuilder.Build();

// 迁移
fsql.CodeFirst.SyncStructure(table.Type);
```

测试创建交叉引用的两个类型，其中Channel可能属于某ChannelGroup（多对一），ChannelGroup包含多个Channel（一对多）：
```C#
// 交叉引用类型，先定义两个类型，再Build
var channelBuilder = fsql.CodeFirst.DynamicEntity("Channel", new TableAttribute { Name = "dm_channel" });
var channelGroupBuilder = fsql.CodeFirst.DynamicEntity("ChannelGroup", new TableAttribute { Name = "dm_channel_group" });

channelBuilder.Property("id", typeof(long), new ColumnAttribute { IsPrimary = true })
    .Property("name", typeof(string), new ColumnAttribute { StringLength = 30 }).Property("channelGroupId", typeof(long?), new ColumnAttribute { IsNullable = true })
    .Property("channelGroupId", typeof(long?))
    .Property("channelGroup", channelGroupBuilder.TypeBuilder, new NavigateAttribute { Bind = "channelGroupId" });

channelGroupBuilder.Property("id", typeof(long), new ColumnAttribute { IsPrimary = true })
    .Property("name", typeof(string), new ColumnAttribute { StringLength = 30 })
    .Property("channels", typeof(List<>).MakeGenericType(channelBuilder.TypeBuilder), new NavigateAttribute { Bind = "channelGroupId" });

// Build时不能立即获取TableInfo，因为类型尚未真正构建
var channelEntityType = channelBuilder.BuildJustType();
var channelGroupEntityType = channelGroupBuilder.BuildJustType();

// 构建后才根据实体类型获取表信息
var channelTable = fsql.CodeFirst.GetTableByEntity(channelEntityType);
var channelGroupTable = fsql.CodeFirst.GetTableByEntity(channelGroupEntityType);

// 迁移
fsql.CodeFirst.SyncStructure(channelEntityType, channelGroupEntityType);
```
