### PR TITLE
添加全局缓存工厂

### DIFF
--- a/Examples/base_entity/MessagePackMap.cs
+++ b/Examples/base_entity/MessagePackMap.cs
@@ -20,7 +20,7 @@ public class MessagePackMap01
     [Key(0)]
     public string name { get; set; }
     [Key(1)]
-    public string address { get;set; }
+    public string address { get; set; }
 }
 
 namespace FreeSql.DataAnnotations
@@ -31,10 +31,10 @@ namespace FreeSql.DataAnnotations
 public static class FreeSqlMessagePackMapCoreExtensions
 {
     internal static int _isAoped = 0;
-    static ConcurrentDictionary<Type, bool> _dicTypes = new ConcurrentDictionary<Type, bool>();
+    static ConcurrentDictionary<Type, bool> _dicTypes = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<Type, bool>>();
     static MethodInfo MethodMessagePackSerializerDeserialize = typeof(MessagePackSerializer).GetMethod("Deserialize", new[] { typeof(Type), typeof(ReadOnlyMemory<byte>), typeof(MessagePackSerializerOptions), typeof(CancellationToken) });
     static MethodInfo MethodMessagePackSerializerSerialize = typeof(MessagePackSerializer).GetMethod("Serialize", new[] { typeof(Type), typeof(object), typeof(MessagePackSerializerOptions), typeof(CancellationToken) });
-    static ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>> _dicMessagePackMapFluentApi = new ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>>();
+    static ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>> _dicMessagePackMapFluentApi = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>>>();
     static object _concurrentObj = new object();
 
     public static ColumnFluent MessagePackMap(this ColumnFluent col)
@@ -55,7 +55,7 @@ public static class FreeSqlMessagePackMapCoreExtensions
         {
             FreeSql.Internal.Utils.GetDataReaderValueBlockExpressionSwitchTypeFullName.Add((LabelTarget returnTarget, Expression valueExp, Type type) =>
             {
-                if (_dicTypes.ContainsKey(type)) 
+                if (_dicTypes.ContainsKey(type))
                     return Expression.IfThenElse(
                     Expression.TypeIs(valueExp, type),
                     Expression.Return(returnTarget, valueExp),

--- a/Extensions/FreeSql.Extensions.AggregateRoot/AggregateRootRepository/AggregateRootUtils.cs
+++ b/Extensions/FreeSql.Extensions.AggregateRoot/AggregateRootRepository/AggregateRootUtils.cs
@@ -18,7 +18,8 @@ namespace FreeSql
 {
     public class AggregateRootUtils
     {
-        static ConcurrentDictionary<PropertyInfo, ConcurrentDictionary<string, AggregateRootBoundaryAttribute>> _dicGetPropertyBoundaryAttribute = new ConcurrentDictionary<PropertyInfo, ConcurrentDictionary<string, AggregateRootBoundaryAttribute>>();
+        static ConcurrentDictionary<PropertyInfo, ConcurrentDictionary<string, AggregateRootBoundaryAttribute>> _dicGetPropertyBoundaryAttribute
+            = Utils.GlobalCacheFactory.CreateCacheItem<ConcurrentDictionary<PropertyInfo, ConcurrentDictionary<string, AggregateRootBoundaryAttribute>>>();
         public static AggregateRootBoundaryAttribute GetPropertyBoundaryAttribute(PropertyInfo prop, string boundaryName)
         {
             if (boundaryName == null) return null;
@@ -161,7 +162,7 @@ namespace FreeSql
                     {
                         if (dictAfter.ContainsKey(key) == false)
                             dictAfter.Add(key, item);
-                        else if (key == "0" && table.Primarys.Length == 1 && 
+                        else if (key == "0" && table.Primarys.Length == 1 &&
                             new[] { typeof(long), typeof(int) }.Contains(table.Primarys[0].CsType))
                             tracking.InsertLog.Add(NativeTuple.Create(elementType, item));
                     }
@@ -215,8 +216,9 @@ namespace FreeSql
             if (propvalBefore == null && propvalAfter != null) return false;
             if (propvalBefore != null && propvalAfter == null) return false;
 
-            if (FreeSql.Internal.Utils.dicExecuteArrayRowReadClassOrTuple.ContainsKey(type)) {
-                if (type.FullName.StartsWith("Newtonsoft.")) 
+            if (FreeSql.Internal.Utils.dicExecuteArrayRowReadClassOrTuple.ContainsKey(type))
+            {
+                if (type.FullName.StartsWith("Newtonsoft."))
                     return object.Equals(propvalBefore.ToString(), propvalAfter.ToString());
 
                 if (typeof(IDictionary).IsAssignableFrom(type))
@@ -261,7 +263,7 @@ namespace FreeSql
 
                 if (type.FullName.StartsWith("System.") ||
                     type.FullName.StartsWith("Npgsql.") ||
-                    type.FullName.StartsWith("NetTopologySuite.")) 
+                    type.FullName.StartsWith("NetTopologySuite."))
                     return object.Equals(propvalBefore, propvalAfter);
 
                 if (type.IsClass)
@@ -434,7 +436,8 @@ namespace FreeSql
             }
         }
 
-        static ConcurrentDictionary<string, ConcurrentDictionary<Type, ConcurrentDictionary<Type, Action<ISelect0>>>> _dicGetAutoIncludeQuery = new ConcurrentDictionary<string, ConcurrentDictionary<Type, ConcurrentDictionary<Type, Action<ISelect0>>>>();
+        static ConcurrentDictionary<string, ConcurrentDictionary<Type, ConcurrentDictionary<Type, Action<ISelect0>>>> _dicGetAutoIncludeQuery 
+            = Utils.GlobalCacheFactory.CreateCacheItem<ConcurrentDictionary<string, ConcurrentDictionary<Type, ConcurrentDictionary<Type, Action<ISelect0>>>>>();
         public static ISelect<TEntity> GetAutoIncludeQuery<TEntity>(string boundaryName, ISelect<TEntity> select)
         {
             var select0p = select as Select0Provider;
@@ -644,8 +647,8 @@ namespace FreeSql
                 case TableRefType.ManyToOne:
                     for (var idx = 0; idx < tbref.RefColumns.Count; idx++)
                     {
-                        var colval = rightItem == null ? 
-                            tbref.Columns[idx].CsType.CreateInstanceGetDefaultValue() : 
+                        var colval = rightItem == null ?
+                            tbref.Columns[idx].CsType.CreateInstanceGetDefaultValue() :
                             Utils.GetDataReaderValue(tbref.Columns[idx].CsType, EntityUtilExtensions.GetEntityValueWithPropertyName(orm, tbref.RefEntityType, rightItem, tbref.RefColumns[idx].CsName));
                         EntityUtilExtensions.SetEntityValueWithPropertyName(orm, leftType, leftItem, tbref.Columns[idx].CsName, colval);
                     }

--- a/Extensions/FreeSql.Extensions.JsonMap/JsonMapCore.cs
+++ b/Extensions/FreeSql.Extensions.JsonMap/JsonMapCore.cs
@@ -10,10 +10,10 @@ using System.Threading;
 public static class FreeSqlJsonMapCoreExtensions
 {
     static int _isAoped = 0;
-    static ConcurrentDictionary<Type, bool> _dicTypes = new ConcurrentDictionary<Type, bool>();
+    static ConcurrentDictionary<Type, bool> _dicTypes = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<Type, bool>>();
     static MethodInfo MethodJsonConvertDeserializeObject = typeof(JsonConvert).GetMethod("DeserializeObject", new[] { typeof(string), typeof(Type) });
     static MethodInfo MethodJsonConvertSerializeObject = typeof(JsonConvert).GetMethod("SerializeObject", new[] { typeof(object), typeof(JsonSerializerSettings) });
-    static ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>> _dicJsonMapFluentApi = new ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>>();
+    static ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>> _dicJsonMapFluentApi = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>>>();
     static object _concurrentObj = new object();
 
     public static ColumnFluent JsonMap(this ColumnFluent col)

--- a/FreeSql.DbContext/DbContext/DbContextAsync.cs
+++ b/FreeSql.DbContext/DbContext/DbContextAsync.cs
@@ -19,7 +19,7 @@ namespace FreeSql
             return SaveChangesSuccess();
         }
 
-        static ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object[], CancellationToken, Task<int>>>> _dicFlushCommandDbSetBatchAsync = new ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object[], CancellationToken, Task<int>>>>();
+        static ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object[], CancellationToken, Task<int>>>> _dicFlushCommandDbSetBatchAsync = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object[], CancellationToken, Task<int>>>>>();
         internal async Task FlushCommandAsync(CancellationToken cancellationToken)
         {
             if (isFlushCommanding) return;

--- a/FreeSql.DbContext/DbContext/DbContextSync.cs
+++ b/FreeSql.DbContext/DbContext/DbContextSync.cs
@@ -31,7 +31,7 @@ namespace FreeSql
             return SaveChangesSuccess();
         }
 
-        static ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object[], int>>> _dicFlushCommandDbSetBatch = new ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object[], int>>>();
+        static ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object[], int>>> _dicFlushCommandDbSetBatch = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object[], int>>>>();
         bool isFlushCommanding = false;
         /// <summary>
         /// 刷新队列中的命令

--- a/FreeSql.DbContext/DbSet/DbSetSync.cs
+++ b/FreeSql.DbContext/DbSet/DbSetSync.cs
@@ -377,7 +377,7 @@ namespace FreeSql
             else if (_table.Properties.TryGetValue(propertyName, out var prop))
                 action(prop);
         }
-        static ConcurrentDictionary<Type, ConcurrentDictionary<string, FieldInfo>> _dicLazyIsSetField = new ConcurrentDictionary<Type, ConcurrentDictionary<string, FieldInfo>>();
+        static ConcurrentDictionary<Type, ConcurrentDictionary<string, FieldInfo>> _dicLazyIsSetField = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<Type, ConcurrentDictionary<string, FieldInfo>>>();
         object GetItemValue(TEntity item, PropertyInfo prop)
         {
             object propVal = null;

--- a/FreeSql.DbContext/Extensions/FreeSqlDbContextExtensions.cs
+++ b/FreeSql.DbContext/Extensions/FreeSqlDbContextExtensions.cs
@@ -40,5 +40,5 @@ public static partial class FreeSqlDbContextExtensions
         _dicSetDbContextOptions.AddOrUpdate(that.Ado.Identifier, cfg, (t, o) => cfg);
         return that;
     }
-    internal static ConcurrentDictionary<Guid, DbContextOptions> _dicSetDbContextOptions = new ConcurrentDictionary<Guid, DbContextOptions>();
+    internal static ConcurrentDictionary<Guid, DbContextOptions> _dicSetDbContextOptions = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<Guid, DbContextOptions>>();
 }

--- a/FreeSql.DbContext/Repository/ContextSet/RepositoryDbContext.cs
+++ b/FreeSql.DbContext/Repository/ContextSet/RepositoryDbContext.cs
@@ -18,7 +18,7 @@ namespace FreeSql
             _repo = repo;
         }
 
-        static ConcurrentDictionary<Type, ConcurrentDictionary<string, FieldInfo>> _dicGetRepositoryDbField = new ConcurrentDictionary<Type, ConcurrentDictionary<string, FieldInfo>>();
+        static ConcurrentDictionary<Type, ConcurrentDictionary<string, FieldInfo>> _dicGetRepositoryDbField = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<Type, ConcurrentDictionary<string, FieldInfo>>>();
         static FieldInfo GetRepositoryDbField(Type type, string fieldName) => _dicGetRepositoryDbField.GetOrAdd(type, tp => new ConcurrentDictionary<string, FieldInfo>()).GetOrAdd(fieldName, fn =>
             typeof(BaseRepository<,>).MakeGenericType(type, typeof(int)).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic));
         public override IDbSet Set(Type entityType)

--- a/FreeSql.DbContext/Repository/DataFilter/DataFilterUtil.cs
+++ b/FreeSql.DbContext/Repository/DataFilter/DataFilterUtil.cs
@@ -13,8 +13,8 @@ namespace FreeSql
 
         internal static Action<FluentDataFilter> _globalDataFilter;
 
-        static ConcurrentDictionary<Type, Delegate> _dicSetRepositoryDataFilterApplyDataFilterFunc = new ConcurrentDictionary<Type, Delegate>();
-        static ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>> _dicSetRepositoryDataFilterConvertFilterNotExists = new ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>>();
+        static ConcurrentDictionary<Type, Delegate> _dicSetRepositoryDataFilterApplyDataFilterFunc = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<Type, Delegate>>();
+        static ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>> _dicSetRepositoryDataFilterConvertFilterNotExists = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>>>();
         internal static void SetRepositoryDataFilter(object repos, Action<FluentDataFilter> scopedDataFilter)
         {
             if (scopedDataFilter != null)

--- a/FreeSql.DbContext/UnitOfWork/UnitOfWork.cs
+++ b/FreeSql.DbContext/UnitOfWork/UnitOfWork.cs
@@ -15,7 +15,7 @@ namespace FreeSql
         /// <summary>
         /// 正在使用中的工作单元（调试）
         /// </summary>
-        public static ConcurrentDictionary<string, UnitOfWork> DebugBeingUsed { get; } = new ConcurrentDictionary<string, UnitOfWork>();
+        public static ConcurrentDictionary<string, UnitOfWork> DebugBeingUsed { get; } = Utils.CacheFactory.CreateCacheItem<ConcurrentDictionary<string, UnitOfWork>>();
 
         protected IFreeSql _fsql;
         protected Object<DbConnection> _conn;

--- a/FreeSql/Extensions/EntityUtilExtensions.cs
+++ b/FreeSql/Extensions/EntityUtilExtensions.cs
@@ -1,4 +1,5 @@
-﻿using FreeSql.Internal.Model;
+﻿using FreeSql.Internal;
+using FreeSql.Internal.Model;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -19,7 +20,8 @@ namespace FreeSql.Extensions.EntityUtil
         static readonly MethodInfo MethodStringConcat = typeof(string).GetMethod("Concat", new Type[] { typeof(object) });
         static readonly MethodInfo MethodFreeUtilNewMongodbId = typeof(FreeUtil).GetMethod("NewMongodbId");
 
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, bool, string>>> _dicGetEntityKeyString = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, bool, string>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, bool, string>>> _dicGetEntityKeyString
+            = Utils.GlobalCacheFactory.CreateCacheItem<ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, bool, string>>>>();
         /// <summary>
         /// 获取实体的主键值，以 "*|_,[,_|*" 分割，当任意一个主键属性无值时，返回 ""
         /// </summary>
@@ -152,7 +154,7 @@ namespace FreeSql.Extensions.EntityUtil
             });
             return func(entity, genGuid);
         }
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, object[]>>> _dicGetEntityKeyValues = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, object[]>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, object[]>>> _dicGetEntityKeyValues = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, object[]>>>());
         /// <summary>
         /// 获取实体的主键值，多个主键返回数组
         /// </summary>
@@ -193,7 +195,8 @@ namespace FreeSql.Extensions.EntityUtil
             });
             return func(entity);
         }
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object>>>> _dicGetEntityValueWithPropertyName = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object>>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object>>>> _dicGetEntityValueWithPropertyName
+            = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, ConcurrentDictionary<string, Func<object, object>>>>());
         /// <summary>
         /// 获取实体的属性值
         /// </summary>
@@ -260,7 +263,7 @@ namespace FreeSql.Extensions.EntityUtil
                 });
             return func(entity);
         }
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, string>>> _dicGetEntityString = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, string>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, string>>> _dicGetEntityString = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, string>>>());
         /// <summary>
         /// 获取实体的所有数据，以 (1, 2, xxx) 的形式
         /// </summary>
@@ -313,7 +316,7 @@ namespace FreeSql.Extensions.EntityUtil
         /// <summary>
         /// 使用新实体的值，复盖旧实体的值
         /// </summary>
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, object>>> _dicMapEntityValue = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, object>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, object>>> _dicMapEntityValue = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, object>>>());
         public static void MapEntityValue(this IFreeSql orm, Type entityType, object entityFrom, object entityTo)
         {
             if (entityType == null) entityType = entityFrom?.GetType() ?? entityTo?.GetType();
@@ -355,7 +358,7 @@ namespace FreeSql.Extensions.EntityUtil
             func(entityFrom, entityTo);
         }
 
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, object>>> _dicMapEntityKeyValue = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, object>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, object>>> _dicMapEntityKeyValue = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, object>>>());
         /// <summary>
         /// 使用新实体的主键值，复盖旧实体的主键值
         /// </summary>
@@ -388,7 +391,7 @@ namespace FreeSql.Extensions.EntityUtil
             func(entityFrom, entityTo);
         }
 
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, long>>> _dicSetEntityIdentityValueWithPrimary = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, long>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, long>>> _dicSetEntityIdentityValueWithPrimary = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, long>>>());
         /// <summary>
         /// 设置实体中主键内的自增字段值（若存在）
         /// </summary>
@@ -424,7 +427,7 @@ namespace FreeSql.Extensions.EntityUtil
             });
             func(entity, idtval);
         }
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, long>>> _dicGetEntityIdentityValueWithPrimary = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, long>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, long>>> _dicGetEntityIdentityValueWithPrimary = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, long>>>());
         /// <summary>
         /// 获取实体中主键内的自增字段值（若存在）
         /// </summary>
@@ -473,7 +476,7 @@ namespace FreeSql.Extensions.EntityUtil
             return func(entity);
         }
 
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object>>> _dicClearEntityPrimaryValueWithIdentityAndGuid = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object>>> _dicClearEntityPrimaryValueWithIdentityAndGuid = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object>>>());
         /// <summary>
         /// 清除实体的主键值，将自增、Guid类型的主键值清除
         /// </summary>
@@ -521,7 +524,7 @@ namespace FreeSql.Extensions.EntityUtil
             func(entity);
         }
 
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object>>> _dicClearEntityPrimaryValueWithIdentity = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object>>> _dicClearEntityPrimaryValueWithIdentity = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object>>>());
         /// <summary>
         /// 清除实体的主键值，将自增、Guid类型的主键值清除
         /// </summary>
@@ -558,7 +561,7 @@ namespace FreeSql.Extensions.EntityUtil
             func(entity);
         }
 
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, object, bool, string[]>>> _dicCompareEntityValueReturnColumns = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, object, bool, string[]>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, object, bool, string[]>>> _dicCompareEntityValueReturnColumns = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Func<object, object, bool, string[]>>>());
         /// <summary>
         /// 对比两个实体值，返回相同/或不相同的列名
         /// </summary>
@@ -625,7 +628,8 @@ namespace FreeSql.Extensions.EntityUtil
             });
             var result = func(entity1, entity2, isEqual);
             var tmptb = orm.CodeFirst.GetTableByEntity(entityType);
-            if (tmptb.ColumnsByCanUpdateDbUpdateValue.Length > 0) {
+            if (tmptb.ColumnsByCanUpdateDbUpdateValue.Length > 0)
+            {
                 if (isEqual && result.Length + tmptb.ColumnsByCanUpdateDbUpdateValue.Length == tmptb.ColumnsByCs.Count)
                     return result.Concat(tmptb.ColumnsByCanUpdateDbUpdateValue.Select(a => a.Attribute.Name)).ToArray();
                 if (!isEqual && result.Length == tmptb.ColumnsByCanUpdateDbUpdateValue.Length)
@@ -634,7 +638,7 @@ namespace FreeSql.Extensions.EntityUtil
             return result;
         }
 
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, string, int>>> _dicSetEntityIncrByWithPropertyName = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, string, int>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, string, int>>> _dicSetEntityIncrByWithPropertyName = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, Action<object, string, int>>>());
         /// <summary>
         /// 设置实体中某属性的数值增加指定的值
         /// </summary>
@@ -678,7 +682,7 @@ namespace FreeSql.Extensions.EntityUtil
             func(entity, propertyName, incrBy);
         }
 
-        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, ConcurrentDictionary<string, Action<object, string, object>>>> _dicSetEntityValueWithPropertyName = new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, ConcurrentDictionary<string, Action<object, string, object>>>>();
+        static ConcurrentDictionary<DataType, ConcurrentDictionary<Type, ConcurrentDictionary<string, Action<object, string, object>>>> _dicSetEntityValueWithPropertyName = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<DataType, ConcurrentDictionary<Type, ConcurrentDictionary<string, Action<object, string, object>>>>());
         /// <summary>
         /// 设置实体中某属性的值
         /// </summary>
@@ -785,8 +789,8 @@ namespace FreeSql.Extensions.EntityUtil
             func(entity, propertyName, value);
         }
 
-        static ConcurrentDictionary<Type, MethodInfo[]> _dicAppendEntityUpdateSetWithColumnMethods = new ConcurrentDictionary<Type, MethodInfo[]>();
-        static ConcurrentDictionary<Type, ConcurrentDictionary<Type, MethodInfo>> _dicAppendEntityUpdateSetWithColumnMethod = new ConcurrentDictionary<Type, ConcurrentDictionary<Type, MethodInfo>>();
+        static ConcurrentDictionary<Type, MethodInfo[]> _dicAppendEntityUpdateSetWithColumnMethods = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, MethodInfo[]>());
+        static ConcurrentDictionary<Type, ConcurrentDictionary<Type, MethodInfo>> _dicAppendEntityUpdateSetWithColumnMethod = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, ConcurrentDictionary<Type, MethodInfo>>());
         /// <summary>
         /// 缓存执行 IUpdate.Set
         /// </summary>

--- a/FreeSql/Extensions/FreeSqlGlobalExtensions.cs
+++ b/FreeSql/Extensions/FreeSqlGlobalExtensions.cs
@@ -182,7 +182,7 @@ public static partial class FreeSqlGlobalExtensions
         return Expression.New(ctor, ctor.GetParameters().Select(a => Expression.Constant(a.ParameterType.CreateInstanceGetDefaultValue(), a.ParameterType)));
     }
 
-    static ConcurrentDictionary<Type, Lazy<ConstructorInfo>> _dicInternalGetTypeConstructor0OrFirst = new ConcurrentDictionary<Type, Lazy<ConstructorInfo>>();
+    static ConcurrentDictionary<Type, Lazy<ConstructorInfo>> _dicInternalGetTypeConstructor0OrFirst = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, Lazy<ConstructorInfo>>());
     internal static ConstructorInfo InternalGetTypeConstructor0OrFirst(this Type that, bool isThrow = true)
     {
         var ret = _dicInternalGetTypeConstructor0OrFirst.GetOrAdd(that, tp =>
@@ -197,7 +197,7 @@ public static partial class FreeSqlGlobalExtensions
         return ret.Value;
     }
 
-    static ConcurrentDictionary<Type, Dictionary<string, PropertyInfo>> _dicGetPropertiesDictIgnoreCase = new ConcurrentDictionary<Type, Dictionary<string, PropertyInfo>>();
+    static ConcurrentDictionary<Type, Dictionary<string, PropertyInfo>> _dicGetPropertiesDictIgnoreCase = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, Dictionary<string, PropertyInfo>>());
     public static Dictionary<string, PropertyInfo> GetPropertiesDictIgnoreCase(this Type that) => that == null ? null : _dicGetPropertiesDictIgnoreCase.GetOrAdd(that, tp =>
     {
         var props = that.GetProperties().GroupBy(p => p.DeclaringType).Reverse().SelectMany(p => p); //将基类的属性位置放在前面 #164
@@ -232,7 +232,7 @@ public static partial class FreeSqlGlobalExtensions
     }
 
     #region Enum 对象扩展方法
-    static ConcurrentDictionary<Type, FieldInfo[]> _dicGetFields = new ConcurrentDictionary<Type, FieldInfo[]>();
+    static ConcurrentDictionary<Type, FieldInfo[]> _dicGetFields = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, FieldInfo[]>());
     public static object GetEnum<T>(this IDataReader dr, int index)
     {
         var value = dr.GetString(index);
@@ -613,7 +613,7 @@ public static partial class FreeSqlGlobalExtensions
     #endregion
 
     #region AsTreeCte(..) 递归查询
-    static ConcurrentDictionary<string, string> _dicMySqlVersion = new ConcurrentDictionary<string, string>();
+    static ConcurrentDictionary<string, string> _dicMySqlVersion = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<string, string>());
     /// <summary>
     /// 使用递归 CTE 查询树型的所有子记录，或者所有父记录。<para></para>
     /// 通过测试的数据库：MySql8.0、SqlServer、PostgreSQL、Oracle、Sqlite、Firebird、达梦、人大金仓、翰高<para></para>
@@ -751,7 +751,7 @@ JOIN {select._commonUtils.QuoteSqlName(tbDbName)} a ON cte_tbc.cte_id = a.{selec
                 case DataType.CustomSqlServer:
                 case DataType.Firebird:
                 case DataType.ClickHouse:
-                    sql1ctePath = select._commonExpression.ExpressionWhereLambda(select._tables, select._tableRule, 
+                    sql1ctePath = select._commonExpression.ExpressionWhereLambda(select._tables, select._tableRule,
                         Expression.Call(typeof(Convert).GetMethod("ToString", new Type[] { typeof(string) }), pathSelector?.Body), select._diymemexpWithTempQuery, null, null);
                     break;
                 case DataType.MySql:

--- a/FreeSql/Extensions/LambadaExpressionExtensions.cs
+++ b/FreeSql/Extensions/LambadaExpressionExtensions.cs
@@ -240,7 +240,6 @@ namespace System.Linq.Expressions
             return test.Result;
         }
 
-        static ConcurrentDictionary<Type, ConcurrentDictionary<string, MethodInfo>> _dicTypeMethod = new ConcurrentDictionary<Type, ConcurrentDictionary<string, MethodInfo>>();
         public static bool IsStringJoin(this MethodCallExpression exp, out Expression tolistObjectExpOut, out MethodInfo toListMethodOut, out LambdaExpression toListArgs0Out)
         {
             if (exp.Arguments.Count == 2 &&

--- a/FreeSql/FreeSqlBuilder.cs
+++ b/FreeSql/FreeSqlBuilder.cs
@@ -12,6 +12,7 @@ using System.Runtime;
 using FreeSql.Internal.Model.Interface;
 using System.Threading;
 using FreeSql.Internal.Model;
+using FreeSql.Interface;
 
 namespace FreeSql
 {
@@ -58,9 +59,21 @@ namespace FreeSql
         /// </summary>
         /// <param name="factory"></param>
         /// <returns></returns>
+        [Obsolete("请使用 UseCacheFactory", true)]
         public FreeSqlBuilder UseCustomTableEntityCacheFactory(Func<ConcurrentDictionary<DataType, ConcurrentDictionary<Type, TableInfo>>> factory)
         {
-            Utils.ChacheTableEntityFactory = factory;
+            Utils._cacheGetTableByEntity = factory.Invoke();
+            return this;
+        }
+
+        /// <summary>
+        /// 解决多实例下相同类型映射到不同表的问题，可以覆盖为从自定义缓存中构建
+        /// </summary>
+        /// <param name="cacheFactory">自定义缓存策略，参考 <see cref="DefaultCacheFactory"/> </param>
+        /// <returns></returns>
+        public FreeSqlBuilder UseCacheFactory(IGlobalCacheFactory cacheFactory)
+        {
+            Utils.GlobalCacheFactory = cacheFactory;
             return this;
         }
         /// <summary>
@@ -646,7 +659,7 @@ namespace FreeSql
             return ret;
         }
         static int _isTypeHandlered = 0;
-        ConcurrentDictionary<Type, bool> _dicTypeHandlerTypes = new ConcurrentDictionary<Type, bool>();
+        ConcurrentDictionary<Type, bool> _dicTypeHandlerTypes = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, bool>());
         object _concurrentObj = new object();
     }
 }

--- a/FreeSql/Interface/IGlobalCacheFactory.cs
+++ b/FreeSql/Interface/IGlobalCacheFactory.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FreeSql.Interface
+{
+    public interface IGlobalCacheFactory
+    {
+        T CreateCacheItem<T>(T defaultValue = null) where T : class, new();
+        T CreateCacheItem<T>() where T : new();
+    }
+}

--- a/FreeSql/Internal/CommonExpression.cs
+++ b/FreeSql/Internal/CommonExpression.cs
@@ -726,7 +726,7 @@ namespace FreeSql.Internal
             var sql = ExpressionLambdaToSql(exp, new ExpTSC { _tables = _tables, _tableRule = _tableRule, diymemexp = diymemexp, tbtype = SelectTableInfoType.From, isQuoteName = true, isDisableDiyParse = false, style = ExpressionStyle.Where, whereGlobalFilter = whereGlobalFilter, dbParams = dbParams });
             return GetBoolString(exp, SearchColumnByField(_tables, null, sql), sql);
         }
-        static ConcurrentDictionary<string, Regex> dicRegexAlias = new ConcurrentDictionary<string, Regex>();
+        static ConcurrentDictionary<string, Regex> dicRegexAlias = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<string, Regex>());
         public void ExpressionJoinLambda(List<SelectTableInfo> _tables, Func<Type, string, string> _tableRule, SelectTableInfoType tbtype, Expression exp, BaseDiyMemberExpression diymemexp, List<GlobalFilter.Item> whereGlobalFilter)
         {
             var tbidx = _tables.Count;
@@ -759,12 +759,12 @@ namespace FreeSql.Internal
                 }
             }
         }
-        static ConcurrentDictionary<Type, MethodInfo> _dicExpressionLambdaToSqlAsSelectMethodInfo = new ConcurrentDictionary<Type, MethodInfo>();
-        static ConcurrentDictionary<Type, MethodInfo> _dicExpressionLambdaToSqlAsSelectWhereMethodInfo = new ConcurrentDictionary<Type, MethodInfo>();
-        static ConcurrentDictionary<Type, MethodInfo> _dicExpressionLambdaToSqlAsSelectWhereSqlMethodInfo = new ConcurrentDictionary<Type, MethodInfo>();
-        static ConcurrentDictionary<Type, ConcurrentDictionary<string, MethodInfo>> _dicExpressionLambdaToSqlAsSelectAggMethodInfo = new ConcurrentDictionary<Type, ConcurrentDictionary<string, MethodInfo>>();
-        internal static ConcurrentDictionary<Type, PropertyInfo> _dicNullableValueProperty = new ConcurrentDictionary<Type, PropertyInfo>();
-        static ConcurrentDictionary<Type, Expression> _dicFreeSqlGlobalExtensionsAsSelectExpression = new ConcurrentDictionary<Type, Expression>();
+        static ConcurrentDictionary<Type, MethodInfo> _dicExpressionLambdaToSqlAsSelectMethodInfo = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, MethodInfo>());
+        static ConcurrentDictionary<Type, MethodInfo> _dicExpressionLambdaToSqlAsSelectWhereMethodInfo = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, MethodInfo>());
+        static ConcurrentDictionary<Type, MethodInfo> _dicExpressionLambdaToSqlAsSelectWhereSqlMethodInfo = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, MethodInfo>());
+        static ConcurrentDictionary<Type, ConcurrentDictionary<string, MethodInfo>> _dicExpressionLambdaToSqlAsSelectAggMethodInfo = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, ConcurrentDictionary<string, MethodInfo>>());
+        internal static ConcurrentDictionary<Type, PropertyInfo> _dicNullableValueProperty = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, PropertyInfo>());
+        static ConcurrentDictionary<Type, Expression> _dicFreeSqlGlobalExtensionsAsSelectExpression = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, Expression>());
         static MethodInfo MethodDateTimeSubtractDateTime = typeof(DateTime).GetMethod("Subtract", new Type[] { typeof(DateTime) });
         static MethodInfo MethodDateTimeSubtractTimeSpan = typeof(DateTime).GetMethod("Subtract", new Type[] { typeof(TimeSpan) });
         static MethodInfo MethodMathFloor = typeof(Math).GetMethod("Floor", new Type[] { typeof(double) });
@@ -962,11 +962,11 @@ namespace FreeSql.Internal
             tsc.SetMapColumnTmp(null).SetMapTypeReturnOld(oldMapType);
             return $"{left} {oper} {right}";
         }
-        static ConcurrentDictionary<Type, bool> _dicTypeExistsExpressionCallAttribute = new ConcurrentDictionary<Type, bool>();
-        static ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>> _dicMethodExistsExpressionCallAttribute = new ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>>();
-        static ConcurrentDictionary<Type, FieldInfo[]> _dicTypeExpressionCallClassContextFields = new ConcurrentDictionary<Type, FieldInfo[]>();
-        static ThreadLocal<List<BaseDiyMemberExpression>> _subSelectParentDiyMemExps = new ThreadLocal<List<BaseDiyMemberExpression>>(); //子查询的所有父自定义查询，比如分组之后的子查询
-        static ConcurrentDictionary<Type, MethodInfo> _dicSelectMethodToSql = new ConcurrentDictionary<Type, MethodInfo>();
+        static ConcurrentDictionary<Type, bool> _dicTypeExistsExpressionCallAttribute = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, bool>());
+        static ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>> _dicMethodExistsExpressionCallAttribute = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>>());
+        static ConcurrentDictionary<Type, FieldInfo[]> _dicTypeExpressionCallClassContextFields = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, FieldInfo[]>());
+        static ThreadLocal<List<BaseDiyMemberExpression>> _subSelectParentDiyMemExps = Utils.GlobalCacheFactory.CreateCacheItem<ThreadLocal<List<BaseDiyMemberExpression>>>(); //子查询的所有父自定义查询，比如分组之后的子查询
+        static ConcurrentDictionary<Type, MethodInfo> _dicSelectMethodToSql = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, MethodInfo>());
         public string ExpressionLambdaToSql(Expression exp, ExpTSC tsc)
         {
             if (exp == null) return "";
@@ -2403,7 +2403,7 @@ namespace FreeSql.Internal
             }
         }
 
-        static ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>> _dicGetWhereCascadeSqlError = new ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>>();
+        static ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>> _dicGetWhereCascadeSqlError = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, ConcurrentDictionary<string, bool>>());
         public string GetWhereCascadeSql(SelectTableInfo tb, IEnumerable<GlobalFilter.Item> filters, bool isMultitb)
         {
             if (filters.Any())

--- a/FreeSql/Internal/CommonProvider/AdoProvider/AdoProviderTransaction.cs
+++ b/FreeSql/Internal/CommonProvider/AdoProvider/AdoProviderTransaction.cs
@@ -30,7 +30,7 @@ namespace FreeSql.Internal.CommonProvider
             }
         }
 
-        private ConcurrentDictionary<int, Transaction2> _trans = new ConcurrentDictionary<int, Transaction2>();
+        private ConcurrentDictionary<int, Transaction2> _trans = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<int, Transaction2>());
 
         public DbTransaction TransactionCurrentThread => _trans.TryGetValue(Thread.CurrentThread.ManagedThreadId, out var conn) && conn.Transaction?.Connection != null ? conn.Transaction : null;
         public Aop.TraceBeforeEventArgs TransactionCurrentThreadAopBefore => _trans.TryGetValue(Thread.CurrentThread.ManagedThreadId, out var conn) && conn.Transaction?.Connection != null ? conn.AopBefore : null;

--- a/FreeSql/Internal/CommonProvider/AdoProvider/AdoProviderUtils.cs
+++ b/FreeSql/Internal/CommonProvider/AdoProvider/AdoProviderUtils.cs
@@ -35,7 +35,7 @@ namespace FreeSql.Internal.CommonProvider
             }
             try { string ret = string.Format(CultureInfo.InvariantCulture, filter, nparms); return ret; } catch { return filter; }
         }
-        static ConcurrentDictionary<int, Regex> _dicAddslashesReplaceIsNull = new ConcurrentDictionary<int, Regex>();
+        static ConcurrentDictionary<int, Regex> _dicAddslashesReplaceIsNull = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<int, Regex>());
 
         protected string AddslashesIEnumerable(object param, Type mapType, ColumnInfo mapColumn)
         {

--- a/FreeSql/Internal/CommonProvider/SelectProvider/Select0Provider.cs
+++ b/FreeSql/Internal/CommonProvider/SelectProvider/Select0Provider.cs
@@ -360,7 +360,7 @@ namespace FreeSql.Internal.CommonProvider
         public static MethodInfo MethodStringContains = typeof(string).GetMethod("Contains", new[] { typeof(string) });
         public static MethodInfo MethodStringStartsWith = typeof(string).GetMethod("StartsWith", new[] { typeof(string) });
         public static MethodInfo MethodStringEndsWith = typeof(string).GetMethod("EndsWith", new[] { typeof(string) });
-        static ConcurrentDictionary<string, MethodInfo> MethodEnumerableDic = new ConcurrentDictionary<string, MethodInfo>();
+        static ConcurrentDictionary<string, MethodInfo> MethodEnumerableDic = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<string, MethodInfo>());
         public static MethodInfo GetMethodEnumerable(string methodName) => MethodEnumerableDic.GetOrAdd(methodName, et =>
         {
             var methods = typeof(Enumerable).GetMethods().Where(a => a.Name == et);
@@ -1237,7 +1237,7 @@ namespace FreeSql.Internal.CommonProvider
                     string.IsNullOrEmpty(testFilter.Value?.ToString());
             }
         }
-        static ConcurrentDictionary<MethodInfo, bool> _dicMethodIsDynamicFilterCustomAttribute = new ConcurrentDictionary<MethodInfo, bool>();
+        static ConcurrentDictionary<MethodInfo, bool> _dicMethodIsDynamicFilterCustomAttribute = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<MethodInfo, bool>());
         static bool MethodIsDynamicFilterCustomAttribute(MethodInfo method) => _dicMethodIsDynamicFilterCustomAttribute.GetOrAdd(method, m =>
         {
             object[] attrs = null;

--- a/FreeSql/Internal/CommonProvider/SelectProvider/Select1Provider.cs
+++ b/FreeSql/Internal/CommonProvider/SelectProvider/Select1Provider.cs
@@ -693,7 +693,7 @@ namespace FreeSql.Internal.CommonProvider
             return NativeTuple.Create(param, members.ToList());
         }
         static MethodInfo GetEntityValueWithPropertyNameMethod = typeof(EntityUtilExtensions).GetMethod("GetEntityValueWithPropertyName");
-        static ConcurrentDictionary<Type, ConcurrentDictionary<string, MethodInfo>> _dicTypeMethod = new ConcurrentDictionary<Type, ConcurrentDictionary<string, MethodInfo>>();
+        static ConcurrentDictionary<Type, ConcurrentDictionary<string, MethodInfo>> _dicTypeMethod = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, ConcurrentDictionary<string, MethodInfo>>());
         public ISelect<T1> IncludeMany<TNavigate>(Expression<Func<T1, IEnumerable<TNavigate>>> navigateSelector, Action<ISelect<TNavigate>> then = null) where TNavigate : class
         {
             var throwNavigateSelector = new Exception(CoreStrings.IncludeMany_ParameterType_Error_Use_MemberAccess);

--- a/FreeSql/Internal/CommonUtils.cs
+++ b/FreeSql/Internal/CommonUtils.cs
@@ -28,7 +28,8 @@ namespace FreeSql.Internal
         public abstract string FormatSql(string sql, params object[] args);
 
         public bool IsQuoteSqlName = true;
-        public string QuoteSqlName(params string[] name) {
+        public string QuoteSqlName(params string[] name)
+        {
             if (IsQuoteSqlName) return QuoteSqlNameAdapter(name);
             if (name == null) return "";
             return string.Join(".", name);
@@ -40,10 +41,10 @@ namespace FreeSql.Internal
         {
             if (string.IsNullOrEmpty(name)) return null;
             if (name.IndexOf(leftQuote) == -1) return name.Split(new[] { '.' }, size);
-            name = Regex.Replace(name, 
-                (leftQuote == '[' ? "\\" : "") + 
+            name = Regex.Replace(name,
+                (leftQuote == '[' ? "\\" : "") +
                 leftQuote + @"([^" + (rightQuote == ']' ? "\\" : "") + rightQuote + @"]+)" +
-                (rightQuote == ']' ? "\\" : "") + 
+                (rightQuote == ']' ? "\\" : "") +
                 rightQuote, m => m.Groups[1].Value.Replace('.', '?'));
             var ret = name.Split(new[] { '.' }, size);
             for (var a = 0; a < ret.Length; a++)
@@ -109,7 +110,7 @@ namespace FreeSql.Internal
             _orm = orm;
         }
 
-        ConcurrentDictionary<Type, TableAttribute> dicConfigEntity = new ConcurrentDictionary<Type, TableAttribute>();
+        ConcurrentDictionary<Type, TableAttribute> dicConfigEntity = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, TableAttribute>());
         public ICodeFirst ConfigEntity<T>(Action<TableFluent<T>> entity)
         {
             if (entity == null) return _orm.CodeFirst;
@@ -135,7 +136,7 @@ namespace FreeSql.Internal
         }
 
         public MappingPriorityType[] _mappingPriorityTypes = new[] { MappingPriorityType.Aop, MappingPriorityType.FluentApi, MappingPriorityType.Attribute };
-        ConcurrentDictionary<Type, Dictionary<string, IndexAttribute>> dicAopConfigEntityIndex = new ConcurrentDictionary<Type, Dictionary<string, IndexAttribute>>();
+        ConcurrentDictionary<Type, Dictionary<string, IndexAttribute>> dicAopConfigEntityIndex = Utils.GlobalCacheFactory.CreateCacheItem<ConcurrentDictionary<Type, Dictionary<string, IndexAttribute>>>();
         public TableAttribute GetEntityTableAttribute(Type type)
         {
             var attr = new TableAttribute();
@@ -156,7 +157,7 @@ namespace FreeSql.Internal
                                     AsTable = attr.AsTable
                                 }
                             };
-                            _orm.Aop.ConfigEntityHandler(_orm, aope); 
+                            _orm.Aop.ConfigEntityHandler(_orm, aope);
                             var tryattr = aope.ModifyResult;
                             if (!string.IsNullOrEmpty(tryattr.Name) && tryattr.Name != type.Name) attr.Name = tryattr.Name;
                             if (!string.IsNullOrEmpty(tryattr.OldName)) attr.OldName = tryattr.OldName;
@@ -618,7 +619,8 @@ namespace FreeSql.Internal
 
             string GetByAttribute(object[] attrs, string attributeName)
             {
-                var dyattr = attrs?.Where(a => {
+                var dyattr = attrs?.Where(a =>
+                {
                     return ((a as Attribute)?.TypeId as Type)?.Name == attributeName;
                 }).FirstOrDefault();
                 if (dyattr == null) return null;
@@ -636,8 +638,8 @@ namespace FreeSql.Internal
                 object[] attrs = null;
                 try
                 {
-                    attrs = prop == null ? 
-                        type.GetCustomAttributes(false).ToArray() : 
+                    attrs = prop == null ?
+                        type.GetCustomAttributes(false).ToArray() :
                         prop.GetCustomAttributes(false).ToArray(); //.net core 反射存在版本冲突问题，导致该方法异常
                 }
                 catch { }

--- a/FreeSql/Internal/DefaultCacheFactory.cs
+++ b/FreeSql/Internal/DefaultCacheFactory.cs
@@ -1,0 +1,21 @@
+﻿using FreeSql.Interface;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FreeSql.Internal
+{
+    public class DefaultCacheFactory : IGlobalCacheFactory
+    {
+        public T CreateCacheItem<T>(T defaultValue = null) where T : class, new()
+        {
+            return defaultValue ?? new T();
+        }
+
+        public T CreateCacheItem<T>() where T : new()
+        {
+            return new T();
+        }
+    }
+}

--- a/FreeSql/Internal/Model/ColumnInfo.cs
+++ b/FreeSql/Internal/Model/ColumnInfo.cs
@@ -65,7 +65,7 @@ namespace FreeSql.Internal.Model
 
 
 
-        static ConcurrentDictionary<ColumnInfo, Func<object, object>> _dicGetMapValue = new ConcurrentDictionary<ColumnInfo, Func<object, object>>();
+        static ConcurrentDictionary<ColumnInfo, Func<object, object>> _dicGetMapValue = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<ColumnInfo, Func<object, object>>());
         [Obsolete("请使用 GetDbValue 或者 GetValue")]
         public object GetMapValue(object obj)
         {
@@ -101,7 +101,7 @@ namespace FreeSql.Internal.Model
             });
             return func(obj);
         }
-        static ConcurrentDictionary<ColumnInfo, Action<object, object>> _dicSetMapValue = new ConcurrentDictionary<ColumnInfo, Action<object, object>>();
+        static ConcurrentDictionary<ColumnInfo, Action<object, object>> _dicSetMapValue = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<ColumnInfo, Action<object, object>>());
         [Obsolete("请使用 SetValue")]
         public void SetMapValue(object obj, object val)
         {

--- a/Providers/FreeSql.Provider.ClickHouse/ClickHouseAdo/ClickHouseConnectionPool.cs
+++ b/Providers/FreeSql.Provider.ClickHouse/ClickHouseAdo/ClickHouseConnectionPool.cs
@@ -67,7 +67,7 @@ namespace FreeSql.ClickHouse
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.Custom/CustomProvider.cs
+++ b/Providers/FreeSql.Provider.Custom/CustomProvider.cs
@@ -86,11 +86,11 @@ namespace FreeSql.Custom
 public static class FreeSqlCustomAdapterGlobalExtensions
 {
     internal static CustomAdapter DefaultAdapter = new CustomAdapter();
-    internal static ConcurrentDictionary<Guid, CustomAdapter> _dicCustomAdater = new ConcurrentDictionary<Guid, CustomAdapter>();
+    internal static ConcurrentDictionary<Guid, CustomAdapter> _dicCustomAdater = Utils.GlobalCacheFactory.CreateCacheItem<ConcurrentDictionary<Guid, CustomAdapter>>();
     public static void SetCustomAdapter(this IFreeSql that, CustomAdapter adapter) => _dicCustomAdater.AddOrUpdate(that.Ado.Identifier, adapter, (fsql, old) => adapter);
     internal static CustomAdapter GetCustomAdapter(this IFreeSql that) => _dicCustomAdater.TryGetValue(that.Ado.Identifier, out var tryada) ? tryada : DefaultAdapter;
 
-    internal static ConcurrentDictionary<Guid, DbProviderFactory> _dicDbProviderFactory = new ConcurrentDictionary<Guid, DbProviderFactory>();
+    internal static ConcurrentDictionary<Guid, DbProviderFactory> _dicDbProviderFactory = Utils.GlobalCacheFactory.CreateCacheItem<ConcurrentDictionary<Guid, DbProviderFactory>>();
     public static void SetDbProviderFactory(this IFreeSql that, DbProviderFactory factory) => _dicDbProviderFactory.AddOrUpdate(that.Ado.Identifier, factory, (fsql, old) => factory);
     internal static DbProviderFactory GetDbProviderFactory(this IFreeSql that) => _dicDbProviderFactory.TryGetValue(that.Ado.Identifier, out var trydbpf) ? trydbpf : throw new Exception("需要先设置 fsql.SetDbProviderFactory(..) 方法");
 }

--- a/Providers/FreeSql.Provider.Custom/Oracle/CustomOracleDbFirst.cs
+++ b/Providers/FreeSql.Provider.Custom/Oracle/CustomOracleDbFirst.cs
@@ -115,7 +115,7 @@ namespace FreeSql.Custom.Oracle
             throw new NotImplementedException(CoreStrings.S_TypeMappingNotImplemented(column.DbTypeTextFull));
         }
 
-        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase));
         static CustomOracleDbFirst()
         {
             var defaultDbToCs = new Dictionary<string, DbToCs>() {

--- a/Providers/FreeSql.Provider.Dameng/DamengAdo/DamengConnectionPool.cs
+++ b/Providers/FreeSql.Provider.Dameng/DamengAdo/DamengConnectionPool.cs
@@ -64,7 +64,7 @@ namespace FreeSql.Dameng
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.Dameng/DamengDbFirst.cs
+++ b/Providers/FreeSql.Provider.Dameng/DamengDbFirst.cs
@@ -57,10 +57,10 @@ namespace FreeSql.Dameng
             }
             if (dbfull?.StartsWith("datetime(") == true)
             {
-				_dicDbToCs.TryAdd(dbfull, _dicDbToCs["timestamp(6)"]);
-				return DmDbType.DateTime;
+                _dicDbToCs.TryAdd(dbfull, _dicDbToCs["timestamp(6)"]);
+                return DmDbType.DateTime;
             }
-			switch (column.DbTypeText?.ToLower())
+            switch (column.DbTypeText?.ToLower())
             {
                 case "bit":
                     _dicDbToCs.TryAdd(dbfull, _dicDbToCs["number(1)"]);
@@ -168,7 +168,7 @@ namespace FreeSql.Dameng
             throw new NotImplementedException(CoreStrings.S_TypeMappingNotImplemented(column.DbTypeTextFull));
         }
 
-        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase));
         static DamengDbFirst()
         {
             var defaultDbToCs = new Dictionary<string, DbToCs>() {

--- a/Providers/FreeSql.Provider.Firebird/FirebirdAdo/FirebirdConnectionPool.cs
+++ b/Providers/FreeSql.Provider.Firebird/FirebirdAdo/FirebirdConnectionPool.cs
@@ -55,7 +55,7 @@ namespace FreeSql.Firebird
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.GBase/GBaseAdo/GBaseConnectionPool.cs
+++ b/Providers/FreeSql.Provider.GBase/GBaseAdo/GBaseConnectionPool.cs
@@ -55,7 +55,7 @@ namespace FreeSql.GBase
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.KingbaseES/KingbaseESAdo/KingbaseESConnectionPool.cs
+++ b/Providers/FreeSql.Provider.KingbaseES/KingbaseESAdo/KingbaseESConnectionPool.cs
@@ -66,7 +66,7 @@ namespace FreeSql.KingbaseES
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.KingbaseES/KingbaseESDbFirst.cs
+++ b/Providers/FreeSql.Provider.KingbaseES/KingbaseESDbFirst.cs
@@ -67,7 +67,7 @@ namespace FreeSql.KingbaseES
             return ret;
         }
 
-        static ConcurrentDictionary<int, DbToCs> _dicDbToCs = new ConcurrentDictionary<int, DbToCs>();
+        static ConcurrentDictionary<int, DbToCs> _dicDbToCs = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<int, DbToCs>());
         static KingbaseESDbFirst()
         {
             var defaultDbToCs = new Dictionary<int, DbToCs>() {

--- a/Providers/FreeSql.Provider.MySql/MySqlAdo/MySqlConnectionPool.cs
+++ b/Providers/FreeSql.Provider.MySql/MySqlAdo/MySqlConnectionPool.cs
@@ -59,7 +59,7 @@ namespace FreeSql.MySql
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.MySqlConnector/MySqlConnectorUtils.cs
+++ b/Providers/FreeSql.Provider.MySqlConnector/MySqlConnectorUtils.cs
@@ -74,7 +74,7 @@ namespace FreeSql.MySql
                 return ret;
             });
 
-        static ConcurrentDictionary<Type, Dictionary<string, int>> _dicEnumNames = new ConcurrentDictionary<Type, Dictionary<string, int>>();
+        static ConcurrentDictionary<Type, Dictionary<string, int>> _dicEnumNames = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, Dictionary<string, int>>());
         static long EnumValueToMySql(object value) //mysqlConnector 不支持 enumString 作为参数化传递，所以要计算出下标值，mysql 下标从 1 开始，并且 c# 设置了枚举元素值会影响下标
         {
             if (value == null) return 0;

--- a/Providers/FreeSql.Provider.Odbc/Dameng/OdbcDamengAdo/OdbcDamengConnectionPool.cs
+++ b/Providers/FreeSql.Provider.Odbc/Dameng/OdbcDamengAdo/OdbcDamengConnectionPool.cs
@@ -66,7 +66,7 @@ namespace FreeSql.Odbc.Dameng
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.Odbc/Dameng/OdbcDamengDbFirst.cs
+++ b/Providers/FreeSql.Provider.Odbc/Dameng/OdbcDamengDbFirst.cs
@@ -168,7 +168,7 @@ namespace FreeSql.Odbc.Dameng
             throw new NotImplementedException(CoreStrings.S_TypeMappingNotImplemented(column.DbTypeTextFull));
         }
 
-        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase));
         static OdbcDamengDbFirst()
         {
             var defaultDbToCs = new Dictionary<string, DbToCs>() {

--- a/Providers/FreeSql.Provider.Odbc/Default/OdbcAdo/OdbcConnectionPool.cs
+++ b/Providers/FreeSql.Provider.Odbc/Default/OdbcAdo/OdbcConnectionPool.cs
@@ -55,7 +55,7 @@ namespace FreeSql.Odbc.Default
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.Odbc/Default/OdbcProvider.cs
+++ b/Providers/FreeSql.Provider.Odbc/Default/OdbcProvider.cs
@@ -91,7 +91,7 @@ namespace FreeSql.Odbc.Default
 partial class FreeSqlOdbcGlobalExtensions
 {
     internal static OdbcAdapter DefaultOdbcAdapter = new OdbcAdapter();
-    internal static ConcurrentDictionary<Guid, OdbcAdapter> _dicOdbcAdater = new ConcurrentDictionary<Guid, OdbcAdapter>();
+    internal static ConcurrentDictionary<Guid, OdbcAdapter> _dicOdbcAdater = Utils.GlobalCacheFactory.CreateCacheItem(Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Guid, OdbcAdapter>());
     public static void SetOdbcAdapter(this IFreeSql that, OdbcAdapter adapter) => _dicOdbcAdater.AddOrUpdate(that.Ado.Identifier, adapter, (fsql, old) => adapter);
     internal static OdbcAdapter GetOdbcAdapter(this IFreeSql that) => _dicOdbcAdater.TryGetValue(that.Ado.Identifier, out var tryada) ? tryada : DefaultOdbcAdapter;
 }

--- a/Providers/FreeSql.Provider.Odbc/KingbaseES/OdbcKingbaseESAdo/OdbcKingbaseESConnectionPool.cs
+++ b/Providers/FreeSql.Provider.Odbc/KingbaseES/OdbcKingbaseESAdo/OdbcKingbaseESConnectionPool.cs
@@ -66,7 +66,7 @@ namespace FreeSql.Odbc.KingbaseES
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.Odbc/KingbaseES/OdbcKingbaseESDbFirst.cs
+++ b/Providers/FreeSql.Provider.Odbc/KingbaseES/OdbcKingbaseESDbFirst.cs
@@ -66,7 +66,7 @@ namespace FreeSql.Odbc.KingbaseES
             return ret;
         }
 
-        static ConcurrentDictionary<int, DbToCs> _dicDbToCs = new ConcurrentDictionary<int, DbToCs>();
+        static ConcurrentDictionary<int, DbToCs> _dicDbToCs = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<int, DbToCs>());
         static OdbcKingbaseESDbFirst()
         {
             var defaultDbToCs = new Dictionary<int, DbToCs>() {

--- a/Providers/FreeSql.Provider.Odbc/MySql/OdbcMySqlAdo/OdbcMySqlConnectionPool.cs
+++ b/Providers/FreeSql.Provider.Odbc/MySql/OdbcMySqlAdo/OdbcMySqlConnectionPool.cs
@@ -55,7 +55,7 @@ namespace FreeSql.Odbc.MySql
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.Odbc/Oracle/OdbcOracleAdo/OdbcOracleConnectionPool.cs
+++ b/Providers/FreeSql.Provider.Odbc/Oracle/OdbcOracleAdo/OdbcOracleConnectionPool.cs
@@ -66,7 +66,7 @@ namespace FreeSql.Odbc.Oracle
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.Odbc/Oracle/OdbcOracleDbFirst.cs
+++ b/Providers/FreeSql.Provider.Odbc/Oracle/OdbcOracleDbFirst.cs
@@ -116,7 +116,7 @@ namespace FreeSql.Odbc.Oracle
             throw new NotImplementedException(CoreStrings.S_TypeMappingNotImplemented(column.DbTypeTextFull));
         }
 
-        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase));
         static OdbcOracleDbFirst()
         {
             var defaultDbToCs = new Dictionary<string, DbToCs>() {

--- a/Providers/FreeSql.Provider.Odbc/PostgreSQL/OdbcPostgreSQLAdo/OdbcPostgreSQLConnectionPool.cs
+++ b/Providers/FreeSql.Provider.Odbc/PostgreSQL/OdbcPostgreSQLAdo/OdbcPostgreSQLConnectionPool.cs
@@ -56,7 +56,7 @@ namespace FreeSql.Odbc.PostgreSQL
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.Odbc/SqlServer/OdbcSqlServerAdo/OdbcSqlServerConnectionPool.cs
+++ b/Providers/FreeSql.Provider.Odbc/SqlServer/OdbcSqlServerAdo/OdbcSqlServerConnectionPool.cs
@@ -55,7 +55,7 @@ namespace FreeSql.Odbc.SqlServer
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.Oracle/OracleAdo/OracleConnectionPool.cs
+++ b/Providers/FreeSql.Provider.Oracle/OracleAdo/OracleConnectionPool.cs
@@ -76,7 +76,7 @@ namespace FreeSql.Oracle
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.Oracle/OracleDbFirst.cs
+++ b/Providers/FreeSql.Provider.Oracle/OracleDbFirst.cs
@@ -213,7 +213,7 @@ namespace FreeSql.Oracle
         }
 #endif
 
-        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase));
         static OracleDbFirst()
         {
             var defaultDbToCs = new Dictionary<string, DbToCs>() {

--- a/Providers/FreeSql.Provider.PostgreSQL/PostgreSQLAdo/PostgreSQLConnectionPool.cs
+++ b/Providers/FreeSql.Provider.PostgreSQL/PostgreSQLAdo/PostgreSQLConnectionPool.cs
@@ -56,7 +56,7 @@ namespace FreeSql.PostgreSQL
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.PostgreSQL/PostgreSQLUtils.cs
+++ b/Providers/FreeSql.Provider.PostgreSQL/PostgreSQLUtils.cs
@@ -164,7 +164,7 @@ namespace FreeSql.PostgreSQL
         public override string QuoteWriteParamterAdapter(Type type, string paramterName) => paramterName;
         protected override string QuoteReadColumnAdapter(Type type, Type mapType, string columnName) => columnName;
 
-        static ConcurrentDictionary<Type, bool> _dicIsAssignableFromPostgisGeometry = new ConcurrentDictionary<Type, bool>();
+        static ConcurrentDictionary<Type, bool> _dicIsAssignableFromPostgisGeometry = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Type, bool>());
         public override string GetNoneParamaterSqlValue(List<DbParameter> specialParams, string specialParamFlag, ColumnInfo col, Type type, object value)
         {
             if (value == null) return "NULL";

--- a/Providers/FreeSql.Provider.QuestDb/QuestDbAdo/QuestDbConnectionPool.cs
+++ b/Providers/FreeSql.Provider.QuestDb/QuestDbAdo/QuestDbConnectionPool.cs
@@ -56,7 +56,7 @@ namespace FreeSql.QuestDb
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.ShenTong/ShenTongAdo/ShenTongConnectionPool.cs
+++ b/Providers/FreeSql.Provider.ShenTong/ShenTongAdo/ShenTongConnectionPool.cs
@@ -54,7 +54,7 @@ namespace FreeSql.ShenTong
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.SqlServer/SqlServerAdo/SqlServerConnectionPool.cs
+++ b/Providers/FreeSql.Provider.SqlServer/SqlServerAdo/SqlServerConnectionPool.cs
@@ -59,7 +59,7 @@ namespace FreeSql.SqlServer
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.SqlServer/SqlServerExtensions.cs
+++ b/Providers/FreeSql.Provider.SqlServer/SqlServerExtensions.cs
@@ -134,7 +134,7 @@ public static partial class FreeSqlSqlServerGlobalExtensions
         _dicSetGlobalSelectWithLock.AddOrUpdate(that.Ado.Identifier, value, (_, __) => value);
         return that;
     }
-    internal static ConcurrentDictionary<Guid, NativeTuple<SqlServerLock, Dictionary<Type, bool>>> _dicSetGlobalSelectWithLock = new ConcurrentDictionary<Guid, NativeTuple<SqlServerLock, Dictionary<Type, bool>>>();
+    internal static ConcurrentDictionary<Guid, NativeTuple<SqlServerLock, Dictionary<Type, bool>>> _dicSetGlobalSelectWithLock = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<Guid, NativeTuple<SqlServerLock, Dictionary<Type, bool>>>());
 
     #region ExecuteSqlBulkCopy
     /// <summary>
@@ -416,7 +416,7 @@ public static partial class FreeSqlSqlServerGlobalExtensions
         }
     }
 #endif
-#endregion
+    #endregion
 }
 
 [Flags]

--- a/Providers/FreeSql.Provider.Sqlite/SqliteDbFirst.cs
+++ b/Providers/FreeSql.Provider.Sqlite/SqliteDbFirst.cs
@@ -105,7 +105,7 @@ namespace FreeSql.Sqlite
             throw new NotImplementedException(CoreStrings.S_TypeMappingNotImplemented(column.DbTypeTextFull));
         }
 
-        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, DbToCs> _dicDbToCs = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<string, DbToCs>(StringComparer.CurrentCultureIgnoreCase));
         static SqliteDbFirst()
         {
             var defaultDbToCs = new Dictionary<string, DbToCs>() {

--- a/Providers/FreeSql.Provider.Xugu/XuguAdo/XuguConnectionPool.cs
+++ b/Providers/FreeSql.Provider.Xugu/XuguAdo/XuguConnectionPool.cs
@@ -53,7 +53,7 @@ namespace FreeSql.Xugu
         public int CheckAvailableInterval { get; set; } = 2;
         public int Weight { get; set; } = 1;
 
-        static ConcurrentDictionary<string, int> dicConnStrIncr = new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase);
+        static ConcurrentDictionary<string, int> dicConnStrIncr = Utils.CacheFactory.CreateCacheItem(new ConcurrentDictionary<string, int>(StringComparer.CurrentCultureIgnoreCase));
         private string _connectionString;
         public string ConnectionString
         {

--- a/Providers/FreeSql.Provider.Xugu/XuguUtils.cs
+++ b/Providers/FreeSql.Provider.Xugu/XuguUtils.cs
@@ -55,16 +55,16 @@ namespace FreeSql.Xugu
             { typeof(ushort).FullName, a => int.Parse(string.Concat(a)) }, { typeof(ushort[]).FullName, a => getParamterArrayValue(typeof(int), a, 0) }, { typeof(ushort?[]).FullName, a => getParamterArrayValue(typeof(int?), a, null) },
             { typeof(byte).FullName, a => short.Parse(string.Concat(a)) }, { typeof(byte[]).FullName, a => getParamterArrayValue(typeof(short), a, 0) }, { typeof(byte?[]).FullName, a => getParamterArrayValue(typeof(short?), a, null) },
             { typeof(sbyte).FullName, a => short.Parse(string.Concat(a)) }, { typeof(sbyte[]).FullName, a => getParamterArrayValue(typeof(short), a, 0) }, { typeof(sbyte?[]).FullName, a => getParamterArrayValue(typeof(short?), a, null) },
-            { typeof(char).FullName, a => string.Concat(a).Replace('\0', ' ').ToCharArray().FirstOrDefault() }, 
+            { typeof(char).FullName, a => string.Concat(a).Replace('\0', ' ').ToCharArray().FirstOrDefault() },
             { typeof(BigInteger).FullName, a => BigInteger.Parse(string.Concat(a), System.Globalization.NumberStyles.Any) }, { typeof(BigInteger[]).FullName, a => getParamterArrayValue(typeof(BigInteger), a, 0) }, { typeof(BigInteger?[]).FullName, a => getParamterArrayValue(typeof(BigInteger?), a, null) },
 
-         
+
             { typeof((IPAddress Address, int Subnet)).FullName, a => {
                 var inet = ((IPAddress Address, int Subnet))a;
                 if (inet.Address == null) return (IPAddress.Any, inet.Subnet);
                 return inet;
-            } }, 
-            { typeof((IPAddress Address, int Subnet)[]).FullName, a => getParamterArrayValue(typeof((IPAddress Address, int Subnet)), a, (IPAddress.Any, 0)) }, 
+            } },
+            { typeof((IPAddress Address, int Subnet)[]).FullName, a => getParamterArrayValue(typeof((IPAddress Address, int Subnet)), a, (IPAddress.Any, 0)) },
             { typeof((IPAddress Address, int Subnet)?[]).FullName, a => getParamterArrayValue(typeof((IPAddress Address, int Subnet)?), a, null) },
         };
         static object getParamterValue(Type type, object value, int level = 0)
@@ -93,17 +93,17 @@ namespace FreeSql.Xugu
             if (string.IsNullOrEmpty(parameterName)) parameterName = $"p_{_params?.Count}";
             if (value != null) value = getParamterValue(type, value);
             var ret = new XGParameters { ParameterName = parameterName, Value = value };
-      
-            var tp = _orm.CodeFirst.GetDbInfo(type)?.type; 
+
+            var tp = _orm.CodeFirst.GetDbInfo(type)?.type;
             if (col != null)
             {
                 var dbtype = (XGDbType?)_orm.DbFirst.GetDbType(new DatabaseModel.DbColumnInfo { DbTypeText = col.DbTypeText });
                 if (dbtype != null)
-                { 
+                {
                     if (col.DbPrecision != 0) ret.Precision = col.DbPrecision;
                     if (col.DbScale != 0) ret.Scale = col.DbScale;
                 }
-            } 
+            }
             _params?.Add(ret);
             return ret;
         }
@@ -113,14 +113,14 @@ namespace FreeSql.Xugu
             {
                 if (value != null) value = getParamterValue(type, value);
                 var ret = new XGParameters { ParameterName = name, Value = value };
-             
+
                 var tp = _orm.CodeFirst.GetDbInfo(type)?.type;
-               
+
                 return ret;
             });
 
         public override string FormatSql(string sql, params object[] args) => sql?.FormatXuguSQL(args);
- 
+
         public override string TrimQuoteSqlName(string name)
         {
             var nametrim = name.Trim();
@@ -140,12 +140,12 @@ namespace FreeSql.Xugu
         public override string QuoteWriteParamterAdapter(Type type, string paramterName) => paramterName;
         protected override string QuoteReadColumnAdapter(Type type, Type mapType, string columnName) => columnName;
 
-        static ConcurrentDictionary<Type, bool> _dicIsAssignableFromPostgisGeometry = new ConcurrentDictionary<Type, bool>();
+        static ConcurrentDictionary<Type, bool> _dicIsAssignableFromPostgisGeometry = Utils.GlobalCacheFactory.CreateCacheItem<ConcurrentDictionary<Type, bool>>();
         public override string GetNoneParamaterSqlValue(List<DbParameter> specialParams, string specialParamFlag, ColumnInfo col, Type type, object value)
         {
             if (value == null) return "NULL";
             if (type.IsNumberType()) return string.Format(CultureInfo.InvariantCulture, "{0}", value);
-     
+
             value = getParamterValue(type, value);
             var type2 = value.GetType();
             if (type2 == typeof(byte[])) return $"'\\x{CommonUtils.BytesSqlRaw(value as byte[])}'";


### PR DESCRIPTION
为全局static 缓存对象 增加 缓存工厂，

由于缓存太多，可能某些需要缓存的对象未包含在内，目前已处理仓库中所有静态 `ConcurrentDictionary` 集合
如果有遗漏的其他类型需要缓存可以直接将初始化方式改为如下方式
```c#
    internal static ConcurrentDictionary<Guid, CustomAdapter> _dicCustomAdater = Utils.GlobalCacheFactory.CreateCacheItem<ConcurrentDictionary<Guid, CustomAdapter>>();

// 或
    internal static ConcurrentDictionary<Guid, CustomAdapter> _dicCustomAdater = Utils.GlobalCacheFactory.CreateCacheItem(new ConcurrentDictionary<Guid, CustomAdapter>);


```

为 Utils 类 增加抽象属性 `GlobalCacheFactory`

```c#
    public interface IGlobalCacheFactory
    {
        T CreateCacheItem<T>(T defaultValue = null) where T : class, new();
        T CreateCacheItem<T>() where T : new();
    }
```

默认实现 `DefaultCacheFactory` , 逻辑上保留默认初始化方式
```c#
    public class DefaultCacheFactory : IGlobalCacheFactory
    {
        public T CreateCacheItem<T>(T defaultValue = null) where T : class, new()
        {
            return defaultValue ?? new T();
        }

        public T CreateCacheItem<T>() where T : new()
        {
            return new T();
        }
    }
```
