### PR TITLE
fix:修复升级达梦数据库的表结构时由于select中字符串精读问题，而导致字符串截取的问题

### DIFF
--- a/FreeSql.Tests/FreeSql.Tests/Dameng/DamengCodeFirstTest.cs
+++ b/FreeSql.Tests/FreeSql.Tests/Dameng/DamengCodeFirstTest.cs
@@ -454,5 +454,74 @@ WHERE (a.""ID"" = 1) AND ROWNUM < 2";
 
         public enum TableAllTypeEnumType1 { e1, e2, e3, e5 }
         [Flags] public enum TableAllTypeEnumType2 { f1, f2, f3 }
+
+
+
+        [Fact]
+        public void UpgradeTableStructure()
+        {
+            g.dameng.CodeFirst.SyncStructure<TableUpgradeTest>();
+
+            g.dameng.Delete<TableUpgradeTest>()
+                .Where(item => 1 == 1)
+                .ExecuteAffrows();
+
+            var text = new StringBuilder();
+            var temp = "1234567890哈";
+            for (int i = 0; i < 3000 - temp.Length; i+= temp.Length)
+            {
+                text.Append(temp);
+            }
+
+            var mode = new TableUpgradeTest 
+            {
+                Name = "1234560123456012哈哈哈哈哈呵呵_123123",
+                Text = text.ToString(),
+                Text2 = "呵呵呵Test123123123"
+            };
+
+            mode.Id = g.dameng.Insert(mode)
+                .ExecuteIdentity();
+
+            // 第二次进行数据库结果同步
+            var sql = g.dameng.CodeFirst.GetComparisonDDLStatements<TableUpgradeTest>();
+            g.dameng.Ado.ExecuteNonQuery(sql);
+            //g.dameng.CodeFirst.SyncStructure<TableSubString>();
+
+            var resultMode = g.dameng.Select<TableUpgradeTest>()
+                .Where(item => item.Id == mode.Id)
+                .First();
+
+            Assert.Equal(mode.Name, resultMode?.Name);
+            Assert.Equal(mode.Text, resultMode?.Text);
+            Assert.Equal(mode.Text2, resultMode?.Text2);
+            Assert.Equal(mode.Text3, resultMode?.Text3);
+
+        }
+
+        [Table(Name = "tb_upgrade_test")]
+        public class TableUpgradeTest
+        {
+            [Column(Name = "id", IsPrimary = true, IsIdentity = true)]
+            public long Id { get; set; }
+
+
+            [Column(Name = "name", StringLength = 31, IsNullable = false)]
+            public string Name { get; set; }
+
+            [Column(Name = "text", StringLength = 32767, IsNullable = false)]
+            public string Text { get; set; }
+
+            [Column(Name = "number_test", IsNullable = false)]
+            public int TestNumber { get; set; }
+
+            [Column(Name = "text2", StringLength = 63)]
+            public string Text2 { get; set; }
+
+
+            [Column(Name = "text3")]
+            public string Text3 { get; set; }
+        }
+
     }
 }

--- a/Providers/FreeSql.Provider.Dameng/DamengCodeFirst.cs
+++ b/Providers/FreeSql.Provider.Dameng/DamengCodeFirst.cs
@@ -358,6 +358,17 @@ and not exists(select 1 from all_constraints where index_name = a.index_name and
                         if (tbcol.Attribute.DbType.StartsWith(tbstructcol.sqlType, StringComparison.CurrentCultureIgnoreCase) == false)
                         {
                             var dbtypeNoneNotNull = Regex.Replace(tbcol.Attribute.DbType, @"(NOT\s+)?NULL", "");
+
+                            var charMatch = Regex.Match(dbtypeNoneNotNull, "(N?)VARCHAR(2?)\\((?<precision>[0-9]+)\\)");
+
+                            if(charMatch != null)
+                            {
+                                if (ushort.TryParse(charMatch.Groups["precision"]?.Value, out var precision))
+                                {
+                                    dbtypeNoneNotNull = Regex.Replace(dbtypeNoneNotNull, $"\\(({precision})\\)", $"");
+                                }
+                            }
+
                             insertvalue = $"cast({insertvalue} as {dbtypeNoneNotNull})";
                         }
                         if (tbcol.Attribute.IsNullable != tbstructcol.is_nullable)


### PR DESCRIPTION
在达梦数据库中，表结构上的字符串长度以**字符**为单位，而在cast函数转换数据类型时，是以**字节**为单位。
我们在使用FreeSql对达梦数据库进行表结构升级时，就会出现重新insert到原表时，一些较长的字符串就会被截断，导致数据不一致。

我跟达梦官方的论坛上提了问题，看这个情况应该就是达梦的特性。。。。
https://eco.dameng.com/community/question/ee053ae1bafba93b665c74a3b3f71b53

同时，我在单元测试中增加了升级测试的代码，原始的代码是不通过的