### PR TITLE
处理人大金仓判断 v9 版本判断为 v8r3版本报错，添加额外条件完善判断

### DIFF
--- a/FreeSql.Tests/FreeSql.Tests/ShenTong/ShenTongCodeFirstTest.cs
+++ b/FreeSql.Tests/FreeSql.Tests/ShenTong/ShenTongCodeFirstTest.cs
@@ -18,7 +18,7 @@ namespace FreeSql.Tests.ShenTong
         {
             var fsql = g.shentong;
             fsql.CodeFirst.SyncStructure<ts_iupstr_bak>();
-            var item = new ts_iupstr { id = Guid.NewGuid(), title = string.Join(",", Enumerable.Range(0, 2000).Select(a => "ÎÒÊÇÖĞ¹úÈË")) };
+            var item = new ts_iupstr { id = Guid.NewGuid(), title = string.Join(",", Enumerable.Range(0, 2000).Select(a => "æˆ‘æ˜¯ä¸­å›½äºº")) };
             Assert.Equal(1, fsql.Insert(item).ExecuteAffrows());
             var find = fsql.Select<ts_iupstr>().Where(a => a.id == item.id).First();
             Assert.NotNull(find);
@@ -55,58 +55,58 @@ namespace FreeSql.Tests.ShenTong
         }
 
         [Fact]
-        public void ÖĞÎÄ±í_×Ö¶Î()
+        public void ä¸­æ–‡è¡¨_å­—æ®µ()
         {
-            var sql = g.shentong.CodeFirst.GetComparisonDDLStatements<²âÊÔÖĞÎÄ±í>();
-            g.shentong.CodeFirst.SyncStructure<²âÊÔÖĞÎÄ±í>();
+            var sql = g.shentong.CodeFirst.GetComparisonDDLStatements<æµ‹è¯•ä¸­æ–‡è¡¨>();
+            g.shentong.CodeFirst.SyncStructure<æµ‹è¯•ä¸­æ–‡è¡¨>();
 
-            var item = new ²âÊÔÖĞÎÄ±í
+            var item = new æµ‹è¯•ä¸­æ–‡è¡¨
             {
-                ±êÌâ = "²âÊÔ±êÌâ",
-                ´´½¨Ê±¼ä = DateTime.Now
+                æ ‡é¢˜ = "æµ‹è¯•æ ‡é¢˜",
+                åˆ›å»ºæ—¶é—´ = DateTime.Now
             };
-            Assert.Equal(1, g.shentong.Insert<²âÊÔÖĞÎÄ±í>().NoneParameter().AppendData(item).ExecuteAffrows());
-            Assert.NotEqual(Guid.Empty, item.±àºÅ);
-            var item2 = g.shentong.Select<²âÊÔÖĞÎÄ±í>().Where(a => a.±àºÅ == item.±àºÅ).First();
+            Assert.Equal(1, g.shentong.Insert<æµ‹è¯•ä¸­æ–‡è¡¨>().NoneParameter().AppendData(item).ExecuteAffrows());
+            Assert.NotEqual(Guid.Empty, item.ç¼–å·);
+            var item2 = g.shentong.Select<æµ‹è¯•ä¸­æ–‡è¡¨>().Where(a => a.ç¼–å· == item.ç¼–å·).First();
             Assert.NotNull(item2);
-            Assert.Equal(item.±àºÅ, item2.±àºÅ);
-            Assert.Equal(item.±êÌâ, item2.±êÌâ);
+            Assert.Equal(item.ç¼–å·, item2.ç¼–å·);
+            Assert.Equal(item.æ ‡é¢˜, item2.æ ‡é¢˜);
 
-            item.±êÌâ = "²âÊÔ±êÌâ¸üĞÂ";
-            Assert.Equal(1, g.shentong.Update<²âÊÔÖĞÎÄ±í>().NoneParameter().SetSource(item).ExecuteAffrows());
-            item2 = g.shentong.Select<²âÊÔÖĞÎÄ±í>().Where(a => a.±àºÅ == item.±àºÅ).First();
+            item.æ ‡é¢˜ = "æµ‹è¯•æ ‡é¢˜æ›´æ–°";
+            Assert.Equal(1, g.shentong.Update<æµ‹è¯•ä¸­æ–‡è¡¨>().NoneParameter().SetSource(item).ExecuteAffrows());
+            item2 = g.shentong.Select<æµ‹è¯•ä¸­æ–‡è¡¨>().Where(a => a.ç¼–å· == item.ç¼–å·).First();
             Assert.NotNull(item2);
-            Assert.Equal(item.±àºÅ, item2.±àºÅ);
-            Assert.Equal(item.±êÌâ, item2.±êÌâ);
+            Assert.Equal(item.ç¼–å·, item2.ç¼–å·);
+            Assert.Equal(item.æ ‡é¢˜, item2.æ ‡é¢˜);
 
-            item.±êÌâ = "²âÊÔ±êÌâ¸üĞÂ_repo";
-            var repo = g.shentong.GetRepository<²âÊÔÖĞÎÄ±í>();
+            item.æ ‡é¢˜ = "æµ‹è¯•æ ‡é¢˜æ›´æ–°_repo";
+            var repo = g.shentong.GetRepository<æµ‹è¯•ä¸­æ–‡è¡¨>();
             repo.DbContextOptions.NoneParameter = true;
             Assert.Equal(1, repo.Update(item));
-            item2 = g.shentong.Select<²âÊÔÖĞÎÄ±í>().Where(a => a.±àºÅ == item.±àºÅ).First();
+            item2 = g.shentong.Select<æµ‹è¯•ä¸­æ–‡è¡¨>().Where(a => a.ç¼–å· == item.ç¼–å·).First();
             Assert.NotNull(item2);
-            Assert.Equal(item.±àºÅ, item2.±àºÅ);
-            Assert.Equal(item.±êÌâ, item2.±êÌâ);
+            Assert.Equal(item.ç¼–å·, item2.ç¼–å·);
+            Assert.Equal(item.æ ‡é¢˜, item2.æ ‡é¢˜);
 
-            item.±êÌâ = "²âÊÔ±êÌâ¸üĞÂ_repo22";
+            item.æ ‡é¢˜ = "æµ‹è¯•æ ‡é¢˜æ›´æ–°_repo22";
             Assert.Equal(1, repo.Update(item));
-            item2 = g.shentong.Select<²âÊÔÖĞÎÄ±í>().Where(a => a.±àºÅ == item.±àºÅ).First();
+            item2 = g.shentong.Select<æµ‹è¯•ä¸­æ–‡è¡¨>().Where(a => a.ç¼–å· == item.ç¼–å·).First();
             Assert.NotNull(item2);
-            Assert.Equal(item.±àºÅ, item2.±àºÅ);
-            Assert.Equal(item.±êÌâ, item2.±êÌâ);
+            Assert.Equal(item.ç¼–å·, item2.ç¼–å·);
+            Assert.Equal(item.æ ‡é¢˜, item2.æ ‡é¢˜);
         }
-        class ²âÊÔÖĞÎÄ±í
+        class æµ‹è¯•ä¸­æ–‡è¡¨
         {
             [Column(IsPrimary = true)]
-            public Guid ±àºÅ { get; set; }
+            public Guid ç¼–å· { get; set; }
 
-            public string ±êÌâ { get; set; }
+            public string æ ‡é¢˜ { get; set; }
 
             [Column(ServerTime = DateTimeKind.Local, CanUpdate = false)]
-            public DateTime ´´½¨Ê±¼ä { get; set; }
+            public DateTime åˆ›å»ºæ—¶é—´ { get; set; }
 
             [Column(ServerTime = DateTimeKind.Local)]
-            public DateTime ¸üĞÂÊ±¼ä { get; set; }
+            public DateTime æ›´æ–°æ—¶é—´ { get; set; }
         }
 
         [Fact]
@@ -168,7 +168,7 @@ namespace FreeSql.Tests.ShenTong
         public void GetComparisonDDLStatements()
         {
             var sql = g.shentong.CodeFirst.GetComparisonDDLStatements<TableAllType>();
-            Assert.True(string.IsNullOrEmpty(sql)); //²âÊÔÔËĞĞÁ½´Îºó
+            Assert.True(string.IsNullOrEmpty(sql)); //æµ‹è¯•è¿è¡Œä¸¤æ¬¡å
             g.shentong.Select<TableAllType>();
         }
 
@@ -196,8 +196,8 @@ namespace FreeSql.Tests.ShenTong
                 //testFieldByteArray = new byte[] { 0, 1, 2, 3, 4, 5, 6 },
                 //testFieldByteArrayNullable = new byte?[] { 0, 1, 2, 3, null, 4, 5, 6 },
                 testFieldByteNullable = byte.MinValue,
-                testFieldBytes = Encoding.UTF8.GetBytes("ÎÒÊÇÖĞ¹úÈË"),
-                //testFieldBytesArray = new[] { Encoding.UTF8.GetBytes("ÎÒÊÇÖĞ¹úÈË"), Encoding.UTF8.GetBytes("ÎÒÊÇÖĞ¹úÈË") },
+                testFieldBytes = Encoding.UTF8.GetBytes("æˆ‘æ˜¯ä¸­å›½äºº"),
+                //testFieldBytesArray = new[] { Encoding.UTF8.GetBytes("æˆ‘æ˜¯ä¸­å›½äºº"), Encoding.UTF8.GetBytes("æˆ‘æ˜¯ä¸­å›½äºº") },
                 testFieldDateTime = DateTime.Now,
                 //testFieldDateTimeArray = new[] { DateTime.Now, DateTime.Now.AddHours(2) },
                 //testFieldDateTimeArrayNullable = new DateTime?[] { DateTime.Now, null, DateTime.Now.AddHours(2) },
@@ -240,9 +240,9 @@ namespace FreeSql.Tests.ShenTong
                 //testFieldShortArray = new short[] { 1, 2, 3, 4, 5 },
                 //testFieldShortArrayNullable = new short?[] { 1, 2, 3, null, 4, 5 },
                 testFieldShortNullable = short.MinValue,
-                testFieldString = "ÎÒÊÇÖĞ¹úÈËstring'\\?!@#$%^&*()_+{}}{~?><<>",
+                testFieldString = "æˆ‘æ˜¯ä¸­å›½äººstring'\\?!@#$%^&*()_+{}}{~?><<>",
                 testFieldChar = 'X',
-                //testFieldStringArray = new[] { "ÎÒÊÇÖĞ¹úÈËString1", "ÎÒÊÇÖĞ¹úÈËString2", null, "ÎÒÊÇÖĞ¹úÈËString3" },
+                //testFieldStringArray = new[] { "æˆ‘æ˜¯ä¸­å›½äººString1", "æˆ‘æ˜¯ä¸­å›½äººString2", null, "æˆ‘æ˜¯ä¸­å›½äººString3" },
                 testFieldTimeSpan = TimeSpan.FromHours(10),
                 //testFieldTimeSpanArray = new[] { TimeSpan.FromHours(10), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(60) },
                 //testFieldTimeSpanArrayNullable = new TimeSpan?[] { TimeSpan.FromHours(10), TimeSpan.FromSeconds(10), null, TimeSpan.FromSeconds(60) },

--- a/Providers/FreeSql.Provider.KingbaseES/KingbaseESCodeFirst.cs
+++ b/Providers/FreeSql.Provider.KingbaseES/KingbaseESCodeFirst.cs
@@ -128,8 +128,14 @@ namespace FreeSql.KingbaseES
                         {
                             return;
                         }
+
                         try
                         {
+                            // v9 版本下面 pg_ sys_ 都支持，导致 v9 版本识别成 v8r3了，需要额外添加判断条件
+                            //SELECT (select 1 from sys_tables limit 1) a,(select 1 from pg_tables limit 1) b;
+                            //经过查看文档 v8r3有命令：show case_sensitive ，v8r6 和以后通过命令 show enable_ci 判断，
+                            //前一个命令不存在了
+                            _orm.Ado.ExecuteNonQuery(" show case_sensitive");
                             _orm.Ado.ExecuteNonQuery(" select 1 from sys_tables limit 1");
                             _isSysV8R3 = true;
                         }


### PR DESCRIPTION
使用的人大金仓数据库版本(`select version();`)：
```
KingbaseES V009R001C002B0014 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-28), 64-bit
```
使用过程中发现第二次调用`fsql.CodeFirst.SyncStructure(table);` 报错，提示索引已存在，发现是判断条件判断表不存在，重复创建，发现是命名空间 `PUBLIC` 和 `pubic` 不对导致，数据库中是public，执行的sql是 PUBLIC

![image](https://github.com/user-attachments/assets/a69dbbf3-2556-4920-8f24-50748df16876)
![image](https://github.com/user-attachments/assets/3282b443-2efb-49db-97f1-200c037b7e04)


![24864445c0514002c39b9362336d451](https://github.com/user-attachments/assets/b9abb7ae-82cd-4c71-9d86-2d1a7693c7e7)

根据下面文档进行修改

https://bbs.kingbase.com.cn/blogDetail?postsId=trans_20646

![1739773147696](https://github.com/user-attachments/assets/a74afeb4-d60c-44d8-a53e-3c8202003d48)

https://bbs.kingbase.com.cn/docHtml?recId=aa82e3addd227d4354cafc2dcb1ff5db&url=aHR0cHM6Ly9iYnMua2luZ2Jhc2UuY29tLmNuL2tpbmdiYXNlLWRvYy92OC42LjcuMjQvZGV2ZWxvcG1lbnQvZGV2ZWxvcC10cmFuc2Zlci90cmFuc3BsYW50LXIzL3RyYW5zcGxhbnQtcjMtMS5odG1sI2lkOA

![1739773196683](https://github.com/user-attachments/assets/b7b3eae1-b2e3-4a41-a1fc-80aa1bb95405)

https://bbs.kingbase.com.cn/docHtml?recId=218c307e5f3d72bf20bb84a51859344a&url=aHR0cHM6Ly9iYnMua2luZ2Jhc2UuY29tLmNuL2tpbmdiYXNlLWRvYy92OS4xLjEuMjQvZGV2ZWxvcG1lbnQvZGV2ZWxvcC10cmFuc2Zlci90cmFuc3BsYW50LXIzL3RyYW5zcGxhbnQtcjMtMS5odG1sI2lkOA
![1739773218318](https://github.com/user-attachments/assets/cd8fd98c-2c59-4c47-ad03-e682af39d9df)
