### PR TITLE
为各项目添加支持 `IsTrimmable` 和 `IsAotCompatible` 的框架以及属性

### DIFF
--- a/Extensions/FreeSql.Extensions.AggregateRoot/FreeSql.Extensions.AggregateRoot.csproj
+++ b/Extensions/FreeSql.Extensions.AggregateRoot/FreeSql.Extensions.AggregateRoot.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net45;net40</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net45;net40;net6.0;net7.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>FreeSql;ncc;YeXiangQin</Authors>
 		<Description>FreeSql 扩展包，聚合根（实现室）.</Description>
@@ -20,6 +20,8 @@
 		<DelaySign>false</DelaySign>
 		<Version>3.5.202</Version>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Extensions/FreeSql.Extensions.BaseEntity/FreeSql.Extensions.BaseEntity.csproj
+++ b/Extensions/FreeSql.Extensions.BaseEntity/FreeSql.Extensions.BaseEntity.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net45;net40</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net45;net40;net6.0;net7.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>FreeSql;ncc;YeXiangQin</Authors>
 		<Description>BaseEntity 是一种极简单的 CodeFirst 开发方式，特别对单表或多表CRUD，利用继承节省了每个实体类的重复属性（创建时间、ID等字段），软件删除等功能，进行 crud 操作时不必时常考虑仓储的使用.</Description>
@@ -21,6 +21,8 @@
 		<LangVersion>latest</LangVersion>
 		<Version>3.5.202</Version>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Extensions/FreeSql.Extensions.JsonMap/FreeSql.Extensions.JsonMap.csproj
+++ b/Extensions/FreeSql.Extensions.JsonMap/FreeSql.Extensions.JsonMap.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net45;net40</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net45;net40;net6.0;net7.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>FreeSql;ncc;YeXiangQin</Authors>
 		<Description>FreeSql 扩展包，可实现实体类属性为对象时，以JSON形式映射存储.</Description>
@@ -20,6 +20,8 @@
 		<DelaySign>false</DelaySign>
 		<Version>3.5.202</Version>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Extensions/FreeSql.Extensions.LazyLoading/FreeSql.Extensions.LazyLoading.csproj
+++ b/Extensions/FreeSql.Extensions.LazyLoading/FreeSql.Extensions.LazyLoading.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;netstandard2.0;net45;net40</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;netstandard2.0;net45;net40;net6.0;net7.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>FreeSql;ncc;YeXiangQin</Authors>
 		<Description>FreeSql 扩展包，可实现【延时加载】属性.</Description>
@@ -17,6 +17,8 @@
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Version>3.5.202</Version>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -24,14 +26,14 @@
 		<None Include="../../logo.png" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+	<ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.2'))">
 		<PackageReference Include="CS-Script.Core" Version="1.3.1" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	<ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.0'))">
 		<PackageReference Include="CS-Script.Core" Version="1.2.3" />
 	</ItemGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' or '$(TargetFramework)' == 'netstandard2.0'">
+	<PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.0'))">
 		<DefineConstants>ns20;netstandard20</DefineConstants>
 	</PropertyGroup>
 

--- a/Extensions/FreeSql.Extensions.Linq/FreeSql.Extensions.Linq.csproj
+++ b/Extensions/FreeSql.Extensions.Linq/FreeSql.Extensions.Linq.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net45;net40</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net45;net40;net6.0;net7.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>FreeSql;ncc;YeXiangQin</Authors>
 		<Description>FreeSql 扩展包，实现 linq queryable 和 linq to sql 语法进行开发.</Description>
@@ -20,6 +20,8 @@
 		<DelaySign>false</DelaySign>
 		<Version>3.5.202</Version>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Extensions/FreeSql.Extensions.ZeroEntity/FreeSql.Extensions.ZeroEntity.csproj
+++ b/Extensions/FreeSql.Extensions.ZeroEntity/FreeSql.Extensions.ZeroEntity.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net45;net40</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net45;net40;net6.0;net7.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>FreeSql;ncc;YeXiangQin</Authors>
 		<Description>FreeSql 扩展包，实现 低代码、零实体、ZeroEntity，并且支持导航属性，级联保存 等功能.</Description>
@@ -20,6 +20,8 @@
 		<DelaySign>false</DelaySign>
 		<Version>3.5.202</Version>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Extensions/FreeSql.Generator/FreeSql.Generator.csproj
+++ b/Extensions/FreeSql.Generator/FreeSql.Generator.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net60</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<IsPackable>true</IsPackable>
 		<PackAsTool>true</PackAsTool>
@@ -15,6 +15,8 @@
 		<PackageTags>FreeSql DbFirst 实体生成器</PackageTags>
 		<Version>3.5.202</Version>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/FreeSql.All/FreeSql.All.csproj
+++ b/FreeSql.All/FreeSql.All.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;netstandard2.0;net45;net40</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;netstandard2.0;net45;net40;net6.0;net7.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>FreeSql;ncc;YeXiangQin</Authors>
 		<Description>FreeSql 全家桶，懒人专用</Description>
@@ -19,6 +19,8 @@
 		<DelaySign>false</DelaySign>
 		<Version>3.5.202</Version>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/FreeSql.DbContext/FreeSql.DbContext.csproj
+++ b/FreeSql.DbContext/FreeSql.DbContext.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;netstandard2.1;netstandard2.0;net45;net40</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;netstandard2.1;netstandard2.0;net45;net40;net6.0;net7.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>FreeSql;ncc;YeXiangQin</Authors>
 		<Description>FreeSql is the ORM in .NetCore, .NetFramework, And Xamarin. It supports Mysql, Postgresql, SqlServer, Oracle, Sqlite, Firebird, Clickhouse, DuckDB, TDengine, QuestDB, Odbc, Oledb, 达梦, 人大金仓, 南大通用, 虚谷, 神舟通用, 翰高, And Access</Description>
@@ -19,6 +19,8 @@
 		<DelaySign>false</DelaySign>
 		<Version>3.5.202</Version>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/FreeSql.Repository/FreeSql.Repository.csproj
+++ b/FreeSql.Repository/FreeSql.Repository.csproj
@@ -19,6 +19,8 @@
 		<DelaySign>false</DelaySign>
 		<Version>3.5.202</Version>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/FreeSql/FreeSql.csproj
+++ b/FreeSql/FreeSql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;netstandard2.0;net451;net45;net40</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;netstandard2.0;net451;net45;net40;net6.0;net7.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>FreeSql;ncc;YeXiangQin</Authors>
 		<Description>FreeSql is the ORM in .NetCore, .NetFramework, And Xamarin. It supports Mysql, Postgresql, SqlServer, Oracle, Sqlite, Firebird, Clickhouse, DuckDB, TDengine, QuestDB, Odbc, Oledb, 达梦, 人大金仓, 南大通用, 虚谷, 神舟通用, 翰高, And Access</Description>
@@ -19,6 +19,8 @@
 		<DelaySign>false</DelaySign>
 		<Version>3.5.202</Version>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
在此 PR 之前，因为多数项目仅面向较旧的框架版本（`net46`, `netstandard2.0` 等），这导致我们无法在项目中启用 `裁剪兼容性检查器` （`IsTrimmable=true`）以及 `AOT兼容性检查器`（`IsAotCompatible=true`），此 PR 为这些项目添加了这些框架（`...;net6.0;net7.0`），并在项目中启用了这两种检查器；现在，在执行项目构建时，对应的项目会正确回报对裁剪、AOT不兼容API的调用。

此 PR 为解决 #2007 的前置条件，因为仅靠在较新框架上发布应用程序并不能涵盖所有API的使用。