### PR TITLE
feat(GlobalFilter): 添加过滤器类型支持并优化各操作过滤逻辑，使其，可以在Select,Update,Delete使用不同的过滤器

### DIFF
--- a/FreeSql.DbContext/Repository/Repository/BaseRepository.cs
+++ b/FreeSql.DbContext/Repository/Repository/BaseRepository.cs
@@ -80,7 +80,6 @@ namespace FreeSql
             get => _unitOfWork;
         }
         public IUpdate<TEntity> UpdateDiy => _dbset.OrmUpdateInternal(null);
-
         public virtual ISelect<TEntity> Select => _dbset.OrmSelectInternal(null);
         public ISelect<TEntity> Where(Expression<Func<TEntity, bool>> exp) => Select.Where(exp);
         public ISelect<TEntity> WhereIf(bool condition, Expression<Func<TEntity, bool>> exp) => Select.WhereIf(condition, exp);

--- a/FreeSql/Internal/CommonProvider/SelectProvider/Select1Provider.cs
+++ b/FreeSql/Internal/CommonProvider/SelectProvider/Select1Provider.cs
@@ -22,7 +22,7 @@ namespace FreeSql.Internal.CommonProvider
     {
         public Select1Provider(IFreeSql orm, CommonUtils commonUtils, CommonExpression commonExpression, object dywhere) : base(orm, commonUtils, commonExpression, dywhere)
         {
-            _whereGlobalFilter = _orm.GlobalFilter.GetFilters();
+            _whereGlobalFilter = _orm.GlobalFilter.GetFilters().Where(l => (l.FilterType & GlobalFilter.FilterType.Query) == GlobalFilter.FilterType.Query).ToList();
         }
 
         protected ISelect<T1> InternalFrom(LambdaExpression lambdaExp)

--- a/FreeSql/Internal/CommonProvider/UpdateProvider.cs
+++ b/FreeSql/Internal/CommonProvider/UpdateProvider.cs
@@ -184,7 +184,7 @@ namespace FreeSql.Internal.CommonProvider
             this.Where(_commonUtils.WhereObject(_table, "", dywhere, _params));
             if (_isAutoSyncStructure && typeof(T1) != typeof(object)) _orm.CodeFirst.SyncStructure<T1>();
             IgnoreCanUpdate();
-            _whereGlobalFilter = _orm.GlobalFilter.GetFilters();
+            _whereGlobalFilter = _orm.GlobalFilter.GetFilters().Where(l => (l.FilterType & GlobalFilter.FilterType.Update) == GlobalFilter.FilterType.Update).ToList();
             _sourceOld = _source;
         }
 
@@ -212,7 +212,7 @@ namespace FreeSql.Internal.CommonProvider
             _params.Clear();
             _paramsSource.Clear();
             IgnoreCanUpdate();
-            _whereGlobalFilter = _orm.GlobalFilter.GetFilters();
+            _whereGlobalFilter = _orm.GlobalFilter.GetFilters().Where(l => (l.FilterType & GlobalFilter.FilterType.Update) == GlobalFilter.FilterType.Update).ToList();
             _batchProgress = null;
             _interceptSql = null;
             _tableAlias = null;


### PR DESCRIPTION
为全局过滤器添加类型支持(查询、更新、删除)，并修改相关操作(Select/Update/Delete)的过滤逻辑，确保只应用对应类型的过滤器。同时修复了RepositoryDbSet中过滤器的禁用逻辑，使其与操作类型匹配。