### PR TITLE
修复数据库无法连接的时候，codefirst的HasData会导致SyncStructure迁移死循环调用，然后Stackoverflow异常

### DIFF
--- a/FreeSql.DbContext/EfCoreFluentApi/EfCoreTableFluent`1.cs
+++ b/FreeSql.DbContext/EfCoreFluentApi/EfCoreTableFluent`1.cs
@@ -344,6 +344,7 @@ namespace FreeSql.Extensions.EfCoreFluentApi
                 lock (sdCopyLock)
                     sd = sdCopy?.ToArray();
                 if (sd == null || sd.Any() == false) return;
+                if (e.Exception != null) return;
                 foreach (var et in e.EntityTypes)
                 {
                     if (et != typeof(T)) continue;

--- a/FreeSql.DbContext/EfCoreFluentApi/EfCoreTableFluent`1.cs
+++ b/FreeSql.DbContext/EfCoreFluentApi/EfCoreTableFluent`1.cs
@@ -340,11 +340,11 @@ namespace FreeSql.Extensions.EfCoreFluentApi
             var sdCopyLock = new object();
             _fsql.Aop.SyncStructureAfter += new EventHandler<Aop.SyncStructureAfterEventArgs>((s, e) =>
             {
+                if (e.Exception != null) return;
                 object[] sd = null;
                 lock (sdCopyLock)
                     sd = sdCopy?.ToArray();
                 if (sd == null || sd.Any() == false) return;
-                if (e.Exception != null) return;
                 foreach (var et in e.EntityTypes)
                 {
                     if (et != typeof(T)) continue;


### PR DESCRIPTION
修复数据库无法连接的时候，codefirst的HasData会导致SyncStructure迁移死循环调用，然后Stackoverflow异常